### PR TITLE
Dev ankr integration 2 2 4 fathom swap library validation of returned data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ fathomapp-subgraph/build
 fathomapp-subgraph/generated
 fathomapp-subgraph/node_modules
 
+*.zip

--- a/contracts/main/price-oracles/lib/FathomSwapLibrary.sol
+++ b/contracts/main/price-oracles/lib/FathomSwapLibrary.sol
@@ -17,14 +17,40 @@ library FathomSwapLibrary {
 
     function getReserves(address factory, address tokenA, address tokenB) internal view returns (uint reserveA, uint reserveB) {
         (address token0, ) = sortTokens(tokenA, tokenB);
-        address pair = pairFor(factory, tokenA, tokenB);
+ 
+        (bool success, bytes memory data1) = factory.staticcall(abi.encodeWithSignature("getPair(address,address)", tokenA, tokenB));
+
+
+        bytes memory empty;
+        //a) check if factory was wrong
+        //if data1 returns empty bytes array, that means factory address had no factory getPair getter fn
+        require(keccak256(data1) != keccak256(empty), "wrong factory address");
+        //b) check if pair address is address(0) or not.
+        //even if factory address was correct, the pair may not exist
+        //revert if it is address(0)
+        require(keccak256(data1) != keccak256(abi.encode(0)), "pair nonexistent");
+
+        //c) pair needs to be converted to address
+        //bytes memory to address
+        //bytes memory data1 -> address...hm...
+        address pair;
+        assembly {
+            pair := data1
+        }
+
         (bool success, bytes memory data) = pair.staticcall(abi.encodeWithSignature("getReserves()"));
+        require(data.length == 0x60, "invalid data length")
         require(success, "getReserves call failed");
+
+        //d) data length check
         uint256 reserve0;
         uint256 reserve1;
         assembly {
             let fmp := mload(0x40)
             mstore(fmp, data)
+            if iszero(data == 0x0) {
+                revert
+            }
             reserve1 := mload(sub(fmp, 0x40))
             reserve0 := mload(sub(fmp, 0x60))
         }


### PR DESCRIPTION
Description
In the FathomSwapLibrary contract the getReserves function will return reserves for non- existent pair, which may lead to incorrect calculations of the price. If the factory address is incorrect, or the pair was not created yet, the staticcall call will not revert and the output variable data will be 0x and the success will be always true . In this case inline assembly block mload(sub(fmp, 0x40)) will work incorrectly and will return the other non-empty internal slot with value 704374636544 . This value will be used in the getPrice function and may lead to incorrect calculations of the price. The getPrice function will return incorrect price for the pair, which may lead to incorrect calculations of the price in the entire system.
Recommendation
We recommend to add a validation of the return length of data after the staticcall call and of the factory variable.