### PR TITLE
Dev ankr integration 2 1 6 useless amount conversion delete

### DIFF
--- a/contracts/main/proxy-actions/FathomStablecoinProxyActions.sol
+++ b/contracts/main/proxy-actions/FathomStablecoinProxyActions.sol
@@ -410,7 +410,6 @@ contract FathomStablecoinProxyActions {
         adjustPosition(_manager, _positionId, -_safeToInt(_collateralAmount), _wipeDebtShare, _xdcAdapter, _data);
         moveCollateral(_manager, _positionId, address(this), _collateralAmount, _xdcAdapter, _data); // Moves the amount from the position to proxy's address
         IGenericTokenAdapter(_xdcAdapter).withdraw(msg.sender, _collateralAmount, _data);
-        IStabilityFeeCollector(_stabilityFeeCollector).collect(_collateralPoolId); // Updates debtAccumulated Rate
         IManager(_manager).updatePrice(_collateralPoolId);
     }
 
@@ -438,7 +437,6 @@ contract FathomStablecoinProxyActions {
         adjustPosition(_manager, _positionId, -_safeToInt(_collateralAmount), -int256(_debtShare), _xdcAdapter, _data); // Paybacks debt to the CDP and unlocks WXDC amount from it
         moveCollateral(_manager, _positionId, address(this), _collateralAmount, _xdcAdapter, _data); // Moves the amount from the CDP positionAddress to proxy's address
         IGenericTokenAdapter(_xdcAdapter).withdraw(msg.sender, _collateralAmount, _data); // Withdraw aXDCc from AnkrCollateralAdapter, fee deducted amount
-        IStabilityFeeCollector(_stabilityFeeCollector).collect(_collateralPoolId); // Updates debtAccumulated Rate
         IManager(_manager).updatePrice(_collateralPoolId);
     }
 

--- a/contracts/main/stablecoin-core/adapters/FarmableTokenAdapter/AnkrCollateralAdapter.sol
+++ b/contracts/main/stablecoin-core/adapters/FarmableTokenAdapter/AnkrCollateralAdapter.sol
@@ -104,10 +104,6 @@ contract AnkrCollateralAdapter is IFarmableTokenAdapter, PausableUpgradeable, Re
         bookKeeper = IBookKeeper(_bookKeeper);
         collateralPoolId = _collateralPoolId;
 
-        // decimals = aXDCcAddress.decimals();
-
-        require(decimals <= 18, "AnkrCollateralAdapter/decimals > 18");
-
         positionManager = IManager(_positionManager);
 
         proxyWalletFactory = IProxyRegistry(_proxyWalletFactory);

--- a/contracts/main/stablecoin-core/adapters/FarmableTokenAdapter/AnkrCollateralAdapter.sol
+++ b/contracts/main/stablecoin-core/adapters/FarmableTokenAdapter/AnkrCollateralAdapter.sol
@@ -31,9 +31,6 @@ contract AnkrCollateralAdapter is IFarmableTokenAdapter, PausableUpgradeable, Re
     IBookKeeper public bookKeeper;
     bytes32 public override collateralPoolId;
 
-    address public override collateralToken;
-    uint256 public override decimals;
-
     IManager public positionManager;
 
     IAnkrStakingPool public XDCPoolAddress;
@@ -50,9 +47,6 @@ contract AnkrCollateralAdapter is IFarmableTokenAdapter, PausableUpgradeable, Re
     mapping(address => uint256) public stake;
 
     mapping(address => bool) public whiteListed;
-
-    uint256 internal to18ConversionFactor;
-    uint256 internal toTokenConversionFactor;
 
     event LogDeposit(uint256 _val);
     event LogWithdraw(uint256 _val);
@@ -110,12 +104,9 @@ contract AnkrCollateralAdapter is IFarmableTokenAdapter, PausableUpgradeable, Re
         bookKeeper = IBookKeeper(_bookKeeper);
         collateralPoolId = _collateralPoolId;
 
-        decimals = aXDCcAddress.decimals();
+        // decimals = aXDCcAddress.decimals();
 
         require(decimals <= 18, "AnkrCollateralAdapter/decimals > 18");
-
-        to18ConversionFactor = 10**(18 - decimals);
-        toTokenConversionFactor = 10**decimals;
 
         positionManager = IManager(_positionManager);
 
@@ -202,7 +193,7 @@ contract AnkrCollateralAdapter is IFarmableTokenAdapter, PausableUpgradeable, Re
         require(_amount == msg.value, "AnkrCollateralAdapter/DepositAmountMismatch");
 
         if (_amount > 0) {
-            uint256 _share = wdiv(mul(_amount, to18ConversionFactor), netAssetPerShare()); // [wad]
+            uint256 _share = wdiv(_amount, netAssetPerShare()); // [wad]
             // Overflow check for int256(wad) cast below
             // Also enforces a non-zero wad
             require(int256(_share) > 0, "AnkrCollateralAdapter/share-overflow");
@@ -262,7 +253,7 @@ contract AnkrCollateralAdapter is IFarmableTokenAdapter, PausableUpgradeable, Re
     /// @param _amount The amount to be deposited
     function _withdraw(address _usr, uint256 _amount) private {
         if (_amount > 0) {
-            uint256 _share = wdivup(mul(_amount, to18ConversionFactor), netAssetPerShare()); // [wad]
+            uint256 _share = wdivup(_amount, netAssetPerShare()); // [wad]
             // Overflow check for int256(wad) cast below
             // Also enforces a non-zero wad
             require(int256(_share) > 0, "AnkrCollateralAdapter/share-overflow");


### PR DESCRIPTION
reasons for fix
we don't need to convert _amount to some other unit since already in ProxyActions contract, the _amount is msg.value(which is wei :10^18) that's why even when to18ConversionFactor was 1, everything worked fine. Therefore I removed needless conversion factors and decimals which comes from aXDCcAddress. This ankrColAdapter doesn't care about aXDCc when it deals with _share.