### PR TITLE
add validations to setStablecoinReferencePrice function, adjust tests

### DIFF
--- a/contracts/main/stablecoin-core/PriceOracle.sol
+++ b/contracts/main/stablecoin-core/PriceOracle.sol
@@ -43,6 +43,8 @@ contract PriceOracle is PausableUpgradeable, ReentrancyGuardUpgradeable, IPriceO
     }
 
     uint256 constant ONE = 10 ** 27;
+    uint256 constant MinReferencePrice = 10 ** 24;
+    uint256 constant MaxReferencePrice = 2 * (10 ** 27);
 
     function mul(uint256 _x, uint256 _y) internal pure returns (uint256 _z) {
         require(_y == 0 || (_z = _x * _y) / _y == _x);
@@ -80,10 +82,12 @@ contract PriceOracle is PausableUpgradeable, ReentrancyGuardUpgradeable, IPriceO
         _;
     }
 
-    function setStableCoinReferencePrice(uint256 _data) external onlyOwner {
+    function setStableCoinReferencePrice(uint256 _referencePrice) external onlyOwner {
         require(live == 1, "PriceOracle/not-live");
-        stableCoinReferencePrice = _data;
-        emit LogSetStableCoinReferencePrice(msg.sender, _data);
+        require(_referencePrice > 0, "PriceOracle/zero-reference-price");
+        require(_referencePrice > MinReferencePrice && _referencePrice < MaxReferencePrice , "PriceOracle/invalid-reference-price");
+        stableCoinReferencePrice = _referencePrice;
+        emit LogSetStableCoinReferencePrice(msg.sender, _referencePrice);
     }
 
     function setPrice(bytes32 _collateralPoolId) external whenNotPaused {

--- a/scripts/tests/unit/stablecoin-core/PriceOracle.test.js
+++ b/scripts/tests/unit/stablecoin-core/PriceOracle.test.js
@@ -102,88 +102,6 @@ describe("PriceOracle", () => {
             .withArgs(formatBytes32String("WXDC"), formatBytes32BigNumber(One), 0, One)
         })
       })
-
-      context("and price with safety margin is 10^43", () => {
-        it("should be success", async () => {
-          await mockedBookKeeper.mock.collateralPoolConfig.returns(mockedCollateralPoolConfig.address)
-          await mockedBookKeeper.mock.accessControlConfig.returns(mockedAccessControlConfig.address)
-          await mockedAccessControlConfig.mock.hasRole.returns(true)
-
-          await mockedPriceFeed.mock.peekPrice.returns(formatBytes32BigNumber(One), true)
-
-          await mockedCollateralPoolConfig.mock.getLiquidationRatio.returns(10 ** 10)
-          await mockedCollateralPoolConfig.mock.collateralPools.returns({
-            totalDebtShare: 0,
-            debtAccumulatedRate: WeiPerRay,
-            priceWithSafetyMargin: WeiPerRay,
-            debtCeiling: 0,
-            debtFloor: 0,
-            priceFeed: mockedPriceFeed.address,
-            liquidationRatio: 10 ** 10,
-            stabilityFeeRate: WeiPerRay,
-            lastAccumulationTime: 0,
-            adapter: AddressZero,
-            closeFactorBps: 5000,
-            liquidatorIncentiveBps: 10250,
-            treasuryFeesBps: 5000,
-            strategy: AddressZero,
-          })
-
-          await priceOracle.setStableCoinReferencePrice(10 ** 10)
-
-          await mockedCollateralPoolConfig.mock.setPriceWithSafetyMargin.withArgs(
-            formatBytes32String("WXDC"),
-            BigNumber.from("10").pow("43")
-          ).returns()
-          await expect(priceOracle.setPrice(formatBytes32String("WXDC")))
-            .to.emit(priceOracle, "LogSetPrice")
-            .withArgs(formatBytes32String("WXDC"), formatBytes32BigNumber(One), BigNumber.from("10").pow("43"), One)
-        })
-      })
-
-      context("and price with safety margin is 9.31322574615478515625 * 10^53", () => {
-        it("should be success", async () => {
-          await mockedBookKeeper.mock.collateralPoolConfig.returns(mockedCollateralPoolConfig.address)
-          await mockedBookKeeper.mock.accessControlConfig.returns(mockedAccessControlConfig.address)
-          await mockedAccessControlConfig.mock.hasRole.returns(true)
-
-          await mockedCollateralPoolConfig.mock.getLiquidationRatio.returns(4 ** 10)
-
-          await mockedPriceFeed.mock.peekPrice.returns(formatBytes32BigNumber(One), true)
-
-          await mockedCollateralPoolConfig.mock.collateralPools.returns({
-            totalDebtShare: 0,
-            debtAccumulatedRate: WeiPerRay,
-            priceWithSafetyMargin: WeiPerRay,
-            debtCeiling: 0,
-            debtFloor: 0,
-            priceFeed: mockedPriceFeed.address,
-            liquidationRatio: 4 ** 10,
-            stabilityFeeRate: WeiPerRay,
-            lastAccumulationTime: 0,
-            adapter: AddressZero,
-            closeFactorBps: 5000,
-            liquidatorIncentiveBps: 10250,
-            treasuryFeesBps: 5000,
-            strategy: AddressZero,
-          })
-
-          await priceOracle.setStableCoinReferencePrice(2 ** 10)
-
-          await mockedCollateralPoolConfig.mock.setPriceWithSafetyMargin.withArgs(
-            formatBytes32String("WXDC"),
-            BigNumber.from("931322574615478515625").mul(BigNumber.from("10").pow("33"))
-          ).returns()
-          await expect(priceOracle.setPrice(formatBytes32String("WXDC")))
-            .to.emit(priceOracle, "LogSetPrice")
-            .withArgs(
-              formatBytes32String("WXDC"),
-              formatBytes32BigNumber(One),
-              BigNumber.from("931322574615478515625").mul(BigNumber.from("10").pow("33")),
-              One
-            )
-        })
-      })
     })
 
     context("when price from price feed is 7 * 10^11", () => {
@@ -224,54 +142,6 @@ describe("PriceOracle", () => {
             .withArgs(formatBytes32String("WXDC"), formatBytes32BigNumber(BigNumber.from("700000000000")), 0, BigNumber.from("700000000000"))
         })
       })
-
-      context("and price with safety margin is 7 * 10^54", () => {
-        it("should be success", async () => {
-          await mockedBookKeeper.mock.collateralPoolConfig.returns(mockedCollateralPoolConfig.address)
-          await mockedBookKeeper.mock.accessControlConfig.returns(mockedAccessControlConfig.address)
-          await mockedAccessControlConfig.mock.hasRole.returns(true)
-
-          await mockedCollateralPoolConfig.mock.getLiquidationRatio.returns(10 ** 10)
-
-          await mockedPriceFeed.mock.peekPrice.returns(
-            formatBytes32BigNumber(BigNumber.from("700000000000")),
-            true,
-          )
-
-          await mockedCollateralPoolConfig.mock.collateralPools.returns({
-            totalDebtShare: 0,
-            debtAccumulatedRate: WeiPerRay,
-            priceWithSafetyMargin: WeiPerRay,
-            debtCeiling: 0,
-            debtFloor: 0,
-            priceFeed: mockedPriceFeed.address,
-            liquidationRatio: 10 ** 10,
-            stabilityFeeRate: WeiPerRay,
-            lastAccumulationTime: 0,
-            adapter: AddressZero,
-            closeFactorBps: 5000,
-            liquidatorIncentiveBps: 10250,
-            treasuryFeesBps: 5000,
-            strategy: AddressZero,
-          })
-
-          await mockedCollateralPoolConfig.mock.setPriceWithSafetyMargin.withArgs(
-            formatBytes32String("WXDC"),
-            BigNumber.from("7").mul(BigNumber.from("10").pow("54"))
-          ).returns()
-
-          await priceOracle.setStableCoinReferencePrice(10 ** 10)
-
-          await expect(priceOracle.setPrice(formatBytes32String("WXDC")))
-            .to.emit(priceOracle, "LogSetPrice")
-            .withArgs(
-              formatBytes32String("WXDC"),
-              formatBytes32BigNumber(BigNumber.from("700000000000")),
-              BigNumber.from("7").mul(BigNumber.from("10").pow("54")),
-              BigNumber.from("700000000000"),
-            )
-        })
-      })
     })
   })
 
@@ -293,13 +163,35 @@ describe("PriceOracle", () => {
           await expect(priceOracle.setStableCoinReferencePrice(10 ** 10)).to.be.revertedWith("PriceOracle/not-live")
         })
       })
-      context("when priceOracle is live", () => {
-        it("should be able to call setStableCoinReferencePrice", async () => {
+      context("new price is 0", () => {
+        it("should revert", async () => {
           await mockedAccessControlConfig.mock.hasRole.returns(true)
 
-          await expect(priceOracle.setStableCoinReferencePrice(10 ** 10))
+          await expect(priceOracle.setStableCoinReferencePrice(0)).to.be.revertedWith("PriceOracle/zero-reference-price")
+        })
+      })
+      context("new price is lower than min", () => {
+        it("should revert", async () => {
+          await mockedAccessControlConfig.mock.hasRole.returns(true)
+
+          await expect(priceOracle.setStableCoinReferencePrice(WeiPerRay.div(1005))).to.be.revertedWith("PriceOracle/invalid-reference-price")
+        })
+      })
+      context("new price is greater than max", () => {
+        it("should revert", async () => {
+          await mockedAccessControlConfig.mock.hasRole.returns(true)
+
+          await expect(priceOracle.setStableCoinReferencePrice(WeiPerRay.mul(3))).to.be.revertedWith("PriceOracle/invalid-reference-price")
+        })
+      })
+      context("when priceOracle is live", () => {
+        it("should be able to call setStableCoinReferencePrice", async () => {
+          const referencePrice = WeiPerRay.mul(11).div(10)
+          await mockedAccessControlConfig.mock.hasRole.returns(true)
+
+          await expect(priceOracle.setStableCoinReferencePrice(referencePrice))
             .to.emit(priceOracle, "LogSetStableCoinReferencePrice")
-            .withArgs(DeployerAddress, 10 ** 10)
+            .withArgs(DeployerAddress, referencePrice)
         })
       })
     })


### PR DESCRIPTION
2.2.3 There are not enough checks in the setStableCoinReferencePrice function in PriceOracle - fixed. added validation to check if the new value is not zero and  match expected range