### PR TITLE
setPriceFeed function update

### DIFF
--- a/contracts/main/interfaces/IFathomOraclePriceFeed.sol
+++ b/contracts/main/interfaces/IFathomOraclePriceFeed.sol
@@ -4,5 +4,5 @@ pragma solidity 0.8.17;
 import "./IPriceFeed.sol";
 
 interface IFathomOraclePriceFeed is IPriceFeed {
-    function initialize(address _fathomOracle, address _token0, address _token1, address _accessControlConfig) external; 
+    function initialize(address _fathomOracle, address _token0, address _token1, address _accessControlConfig, bytes32 _poolId) external; 
 }

--- a/contracts/main/interfaces/IPriceFeed.sol
+++ b/contracts/main/interfaces/IPriceFeed.sol
@@ -7,4 +7,6 @@ interface IPriceFeed {
     function peekPrice() external returns (bytes32, bool); // [wad]
 
     function isPriceOk() external view returns (bool);
+
+    function poolId() external view returns (bytes32);
 }

--- a/contracts/main/price-feeders/DelayFathomOraclePriceFeed.sol
+++ b/contracts/main/price-feeders/DelayFathomOraclePriceFeed.sol
@@ -101,6 +101,10 @@ contract DelayFathomOraclePriceFeed is PausableUpgradeable, IFathomOraclePriceFe
         require(_oracle != address(0), "FathomOraclePriceFeed: ZERO_ADDRESS");
         fathomOracle = IFathomOracle(_oracle);
     }
+    
+    function setPoolId(bytes32 _poolId) external onlyOwner {
+       poolId = _poolId;
+    }
 
     function pause() external onlyOwnerOrGov {
         _pause();

--- a/contracts/main/price-feeders/DelayFathomOraclePriceFeed.sol
+++ b/contracts/main/price-feeders/DelayFathomOraclePriceFeed.sol
@@ -13,13 +13,14 @@ contract DelayFathomOraclePriceFeed is PausableUpgradeable, IFathomOraclePriceFe
     uint256 public lastUpdateTS;
     uint256 public timeDelay;
     uint256 public priceLife;
+    bytes32 public poolId;
 
     IFathomOracle public fathomOracle;
     IAccessControlConfig public accessControlConfig;
     address public token0;
     address public token1;
 
-    function initialize(address _fathomOracle, address _token0, address _token1, address _accessControlConfig) external initializer {
+    function initialize(address _fathomOracle, address _token0, address _token1, address _accessControlConfig, bytes32 _poolId) external initializer {
         PausableUpgradeable.__Pausable_init();
 
         require(_accessControlConfig != address(0), "FathomOraclePriceFeed: ZERO_ADDRESS");
@@ -32,6 +33,7 @@ contract DelayFathomOraclePriceFeed is PausableUpgradeable, IFathomOraclePriceFe
         token1 = _token1;
         priceLife = 30 minutes;
         timeDelay = 15 minutes;
+        poolId = _poolId;
     }
 
     modifier onlyOwner() {

--- a/contracts/main/stablecoin-core/config/CollateralPoolConfig.sol
+++ b/contracts/main/stablecoin-core/config/CollateralPoolConfig.sol
@@ -112,6 +112,12 @@ contract CollateralPoolConfig is AccessControlUpgradeable, ICollateralPoolConfig
     }
 
     function setPriceFeed(bytes32 _poolId, address _priceFeed) external onlyOwner {
+        require(_priceFeed != address(0), "CollateralPoolConfig/zero-price-feed");
+        require(IPriceFeed(_priceFeed).poolId() == _poolId, "CollateralPoolConfig/wrong-price-feed-pool");
+        require(IPriceFeed(_priceFeed).isPriceOk(), "CollateralPoolConfig/unhealthy-price-feed");
+
+        IPriceFeed(_priceFeed).peekPrice();
+
         _collateralPools[_poolId].priceFeed = _priceFeed;
         emit LogSetPriceFeed(msg.sender, _poolId, _priceFeed);
     }

--- a/contracts/main/stablecoin-core/config/CollateralPoolConfig.sol
+++ b/contracts/main/stablecoin-core/config/CollateralPoolConfig.sol
@@ -74,7 +74,11 @@ contract CollateralPoolConfig is AccessControlUpgradeable, ICollateralPoolConfig
         _collateralPools[_collateralPoolId].debtAccumulatedRate = RAY;
         _collateralPools[_collateralPoolId].debtCeiling = _debtCeiling;
         _collateralPools[_collateralPoolId].debtFloor = _debtFloor;
+        
+        require(IPriceFeed(_priceFeed).poolId() == _collateralPoolId, "CollateralPoolConfig/wrong-price-feed-pool");
+        require(IPriceFeed(_priceFeed).isPriceOk(), "CollateralPoolConfig/unhealthy-price-feed");
         IPriceFeed(_priceFeed).peekPrice(); // Sanity Check Call
+
         _collateralPools[_collateralPoolId].priceFeed = _priceFeed;
         require(_liquidationRatio >= RAY, "CollateralPoolConfig/invalid-liquidation-ratio");
         _collateralPools[_collateralPoolId].liquidationRatio = _liquidationRatio;

--- a/contracts/tests/mocks/SimplePriceFeed.sol
+++ b/contracts/tests/mocks/SimplePriceFeed.sol
@@ -12,6 +12,7 @@ contract SimplePriceFeed is PausableUpgradeable, AccessControlUpgradeable, IPric
 
     uint256 public price;
     uint256 public lastUpdate;
+    bytes32 public poolId;
 
     uint256 public priceLife;
 
@@ -52,6 +53,10 @@ contract SimplePriceFeed is PausableUpgradeable, AccessControlUpgradeable, IPric
         require(_second >= 1 hours && _second <= 365 days, "SimplePriceFeed/bad-price-life");
         priceLife = _second;
         emit LogSetPriceLife(msg.sender, _second);
+    }
+
+    function setPoolId(bytes32 _poolId) external {
+        poolId = _poolId;
     }
 
     function pause() external onlyOwnerOrGov {

--- a/scripts/migrations/deployment/3_initialize.js
+++ b/scripts/migrations/deployment/3_initialize.js
@@ -113,9 +113,10 @@ module.exports = async function (deployer) {
         ),
         delayFathomOraclePriceFeed.initialize(
             dexPriceOracle.address,
-            addresses.USD,
             addresses.WXDC,
-            accessControlConfig.address
+            addresses.USD,
+            accessControlConfig.address,
+            pools.XDC
         ),
     ];
 

--- a/scripts/tests/unit/config/CollateralPoolConfig.test.js
+++ b/scripts/tests/unit/config/CollateralPoolConfig.test.js
@@ -73,6 +73,8 @@ describe("CollateralPoolConfig", () => {
     context("when the caller is not the owner", () => {
       it("should be revert", async () => {
         await mockedAccessControlConfig.mock.hasRole.returns(false)
+        await mockedSimplePriceFeed.mock.poolId.returns(COLLATERAL_POOL_ID)
+        await mockedSimplePriceFeed.mock.isPriceOk.returns(true)
 
         await expect(
           collateralPoolConfigAsAlice.initCollateralPool(
@@ -93,6 +95,9 @@ describe("CollateralPoolConfig", () => {
     })
     context("when collateral pool already init", () => {
       it("should be revert", async () => {
+        await mockedSimplePriceFeed.mock.poolId.returns(COLLATERAL_POOL_ID)
+        await mockedSimplePriceFeed.mock.isPriceOk.returns(true)
+
         await collateralPoolConfig.initCollateralPool(
           COLLATERAL_POOL_ID,
           WeiPerRad.mul(10000000),
@@ -125,6 +130,9 @@ describe("CollateralPoolConfig", () => {
     })
     context("when stability fee rate invalid", () => {
       it("should be revert", async () => {
+        await mockedSimplePriceFeed.mock.poolId.returns(COLLATERAL_POOL_ID)
+        await mockedSimplePriceFeed.mock.isPriceOk.returns(true)
+
         await expect(
           collateralPoolConfig.initCollateralPool(
             COLLATERAL_POOL_ID,
@@ -142,8 +150,55 @@ describe("CollateralPoolConfig", () => {
         ).to.be.revertedWith("CollateralPoolConfig/invalid-stability-fee-rate")
       })
     })
+    context("price feed is not healthy", () => {
+      it("should revert", async () => {
+        await mockedSimplePriceFeed.mock.poolId.returns(COLLATERAL_POOL_ID)
+        await mockedSimplePriceFeed.mock.isPriceOk.returns(false)
+
+        await expect(
+          collateralPoolConfig.initCollateralPool(
+            COLLATERAL_POOL_ID,
+            WeiPerRad.mul(10000000),
+            0,
+            mockedSimplePriceFeed.address,
+            WeiPerRay,
+            WeiPerWad,
+            mockedCollateralTokenAdapter.address,
+            CLOSE_FACTOR_BPS,
+            LIQUIDATOR_INCENTIVE_BPS,
+            TREASURY_FEE_BPS,
+            AddressZero
+          )
+        ).to.be.revertedWith("CollateralPoolConfig/unhealthy-price-feed")
+      })
+    })
+    context("wrong price feed pool", () => {
+      it("should revert", async () => {
+        await mockedSimplePriceFeed.mock.poolId.returns(formatBytes32String("GOLD"))
+        await mockedSimplePriceFeed.mock.isPriceOk.returns(true)
+
+        await expect(
+          collateralPoolConfig.initCollateralPool(
+            COLLATERAL_POOL_ID,
+            WeiPerRad.mul(10000000),
+            0,
+            mockedSimplePriceFeed.address,
+            WeiPerRay,
+            WeiPerWad,
+            mockedCollateralTokenAdapter.address,
+            CLOSE_FACTOR_BPS,
+            LIQUIDATOR_INCENTIVE_BPS,
+            TREASURY_FEE_BPS,
+            AddressZero
+          )
+        ).to.be.revertedWith("CollateralPoolConfig/wrong-price-feed-pool")
+      })
+    })
     context("when parameters are valid", () => {
       it("should success", async () => {
+        await mockedSimplePriceFeed.mock.poolId.returns(COLLATERAL_POOL_ID)
+        await mockedSimplePriceFeed.mock.isPriceOk.returns(true)
+        
         await collateralPoolConfig.initCollateralPool(
           COLLATERAL_POOL_ID,
           WeiPerRad.mul(10000000),

--- a/scripts/tests/unit/price-feeds/DelayFathomOraclePriceFeed.test.js
+++ b/scripts/tests/unit/price-feeds/DelayFathomOraclePriceFeed.test.js
@@ -3,14 +3,15 @@ const { expect } = chai
 const { solidity } = require("ethereum-waffle");
 chai.use(solidity);
 
-const { BigNumber, ethers } = require("ethers");
+const { ethers } = require("ethers");
 
 const { WeiPerRad, WeiPerRay, WeiPerWad } = require("../../helper/unit");
 const { DeployerAddress } = require("../../helper/address");
 const { getContract, createMock } = require("../../helper/contracts");
 const { increase, latest } = require('../../helper/time');
-
 const { formatBytes32String } = ethers.utils
+
+const COLLATERAL_POOL_ID = formatBytes32String("XDC")
 
 describe("Delay Fathom Oracle with MockedDexPriceOracle - Unit Test Suite", () => {
   let mockedBookKeeper //  <- bookKeeper.collateralPoolConfig() should return the address of mockCollateralPoolConfig
@@ -38,7 +39,7 @@ describe("Delay Fathom Oracle with MockedDexPriceOracle - Unit Test Suite", () =
     await mockedBookKeeper.mock.collateralPoolConfig.returns(mockedCollateralPoolConfig.address);
     await mockedCollateralPoolConfig.mock.getLiquidationRatio.returns(WeiPerRay);
 
-    await delayFathomOraclePriceFeed.initialize(mockedDexPriceOracle.address, mockToken0, mockToken1, mockedAccessControlConfig.address);
+    await delayFathomOraclePriceFeed.initialize(mockedDexPriceOracle.address, mockToken0, mockToken1, mockedAccessControlConfig.address, COLLATERAL_POOL_ID);
   })
 
   describe("DelayFathomOraclePriceFeed Contract Tests", () => {


### PR DESCRIPTION
2.2.12 There are not enough checks in the setPriceFeed function in CollateralPoolConfig - fixed.
added check:
-zero address check
- added poolId to IPriceOrale and now we compare it to the collateralPoolId
- call isPriceOk to prevent unhealthy price feed setting
added peekPrice call
adjusted tests