### PR TITLE
add validations to setLiquidationRatio function

### DIFF
--- a/contracts/main/stablecoin-core/StableSwapModule.sol
+++ b/contracts/main/stablecoin-core/StableSwapModule.sol
@@ -196,7 +196,7 @@ contract StableSwapModule is PausableUpgradeable, ReentrancyGuardUpgradeable, IS
         uint256 _amount,
         uint8 _fromDecimals,
         uint8 _toDecimals
-    ) internal returns (uint256 result) {
+    ) internal pure returns (uint256 result) {
         result = _toDecimals >= _fromDecimals ? _amount * (10**(_toDecimals - _fromDecimals)) : _amount / (10**(_fromDecimals - _toDecimals));
     }
 }

--- a/contracts/main/stablecoin-core/config/CollateralPoolConfig.sol
+++ b/contracts/main/stablecoin-core/config/CollateralPoolConfig.sol
@@ -115,10 +115,11 @@ contract CollateralPoolConfig is AccessControlUpgradeable, ICollateralPoolConfig
         _collateralPools[_poolId].priceFeed = _priceFeed;
         emit LogSetPriceFeed(msg.sender, _poolId, _priceFeed);
     }
-
-    function setLiquidationRatio(bytes32 _poolId, uint256 _data) external onlyOwner {
-        _collateralPools[_poolId].liquidationRatio = _data;
-        emit LogSetLiquidationRatio(msg.sender, _poolId, _data);
+     
+    function setLiquidationRatio(bytes32 _poolId, uint256 _liquidationRatio) external onlyOwner {
+        require(_liquidationRatio >= RAY && _liquidationRatio < RAY * 100, "CollateralPoolConfig/invalid-liquidation-ratio");
+        _collateralPools[_poolId].liquidationRatio = _liquidationRatio;
+        emit LogSetLiquidationRatio(msg.sender, _poolId, _liquidationRatio);
     }
 
     /** @dev Set the stability fee rate of the collateral pool.

--- a/contracts/main/stablecoin-core/config/CollateralPoolConfig.sol
+++ b/contracts/main/stablecoin-core/config/CollateralPoolConfig.sol
@@ -117,7 +117,7 @@ contract CollateralPoolConfig is AccessControlUpgradeable, ICollateralPoolConfig
     }
      
     function setLiquidationRatio(bytes32 _poolId, uint256 _liquidationRatio) external onlyOwner {
-        require(_liquidationRatio >= RAY && _liquidationRatio < RAY * 100, "CollateralPoolConfig/invalid-liquidation-ratio");
+        require(_liquidationRatio >= RAY && _liquidationRatio <= RAY * 100, "CollateralPoolConfig/invalid-liquidation-ratio");
         _collateralPools[_poolId].liquidationRatio = _liquidationRatio;
         emit LogSetLiquidationRatio(msg.sender, _poolId, _liquidationRatio);
     }

--- a/scripts/tests/unit/config/CollateralPoolConfig.test.js
+++ b/scripts/tests/unit/config/CollateralPoolConfig.test.js
@@ -262,6 +262,20 @@ describe("CollateralPoolConfig", () => {
         )
       })
     })
+    context("ratio less than ray", () => {
+      it("should revert", async () => {
+        await expect(collateralPoolConfigAsAlice.setLiquidationRatio(COLLATERAL_POOL_ID, WeiPerRay.sub(1))).to.be.revertedWith(
+          "CollateralPoolConfig/invalid-liquidation-ratio"
+        )
+      })
+    })
+    context("ratio higher than max", () => {
+      it("should revert", async () => {
+        await expect(collateralPoolConfigAsAlice.setLiquidationRatio(COLLATERAL_POOL_ID, WeiPerRay.mul(101))).to.be.revertedWith(
+          "CollateralPoolConfig/invalid-liquidation-ratio"
+        )
+      })
+    })
     context("when parameters are valid", () => {
       it("should success", async () => {
         await expect(collateralPoolConfig.setLiquidationRatio(COLLATERAL_POOL_ID, WeiPerRay))


### PR DESCRIPTION
2.2.13 There are not enough checks in the setLiquidationRatio function in CollateralPoolConfig - fixed.
added validations to check if liquidationRatio >= min and liquidationRatio =< max