### PR TITLE
now we will spend liquidator's stablecoin instead of recipient's to liquidate the position

### DIFF
--- a/contracts/main/stablecoin-core/liquidation-strategies/FixedSpreadLiquidationStrategy.sol
+++ b/contracts/main/stablecoin-core/liquidation-strategies/FixedSpreadLiquidationStrategy.sol
@@ -192,7 +192,7 @@ contract FixedSpreadLiquidationStrategy is PausableUpgradeable, ReentrancyGuardU
         address _positionAddress, // Address that will receive any leftover collateral
         uint256 _debtShareToBeLiquidated, // The value of debt to be liquidated as specified by the liquidator [rad]
         uint256 _maxDebtShareToBeLiquidated, // The maximum value of debt to be liquidated as specified by the liquidator in case of full liquidation for slippage control [rad]
-        address _liquidatorAddress,  //<- liq. engine's address
+        address _liquidatorAddress,
         address _collateralRecipient,
         bytes calldata _data // Data to pass in external call; if length 0, no call is done
     ) external override nonReentrant whenNotPaused {
@@ -258,10 +258,10 @@ contract FixedSpreadLiquidationStrategy is PausableUpgradeable, ReentrancyGuardU
         }
 
         address _stablecoin = address(stablecoinAdapter.stablecoin());
-        _stablecoin.safeTransferFrom(_collateralRecipient, address(this), ((info.actualDebtValueToBeLiquidated / RAY) + 1));
+        _stablecoin.safeTransferFrom(_liquidatorAddress, address(this), ((info.actualDebtValueToBeLiquidated / RAY) + 1));
         _stablecoin.safeApprove(address(stablecoinAdapter), ((info.actualDebtValueToBeLiquidated / RAY) + 1));
-        stablecoinAdapter.depositRAD(_collateralRecipient, info.actualDebtValueToBeLiquidated, abi.encode(0));
-        bookKeeper.moveStablecoin(_collateralRecipient, address(systemDebtEngine), info.actualDebtValueToBeLiquidated);
+        stablecoinAdapter.depositRAD(_liquidatorAddress, info.actualDebtValueToBeLiquidated, abi.encode(0));
+        bookKeeper.moveStablecoin(_liquidatorAddress, address(systemDebtEngine), info.actualDebtValueToBeLiquidated);
 
         info.positionDebtShare = _positionDebtShare;
         info.positionCollateralAmount = _positionCollateralAmount;


### PR DESCRIPTION
2.2.11 Stablecoins from any _collateralReceiver address can be used to liquidate tokens in LiquidationEngine - fixed. now we use stablecoins from the liquidators address