### PR TITLE
add validation to setDebtAccumulatedRate function

### DIFF
--- a/contracts/main/stablecoin-core/config/CollateralPoolConfig.sol
+++ b/contracts/main/stablecoin-core/config/CollateralPoolConfig.sol
@@ -186,6 +186,7 @@ contract CollateralPoolConfig is AccessControlUpgradeable, ICollateralPoolConfig
 
     function setDebtAccumulatedRate(bytes32 _collateralPoolId, uint256 _debtAccumulatedRate) external override {
         require(accessControlConfig.hasRole(accessControlConfig.BOOK_KEEPER_ROLE(), msg.sender), "!bookKeeperRole");
+        require(_debtAccumulatedRate >= RAY, "CollateralPoolConfig/invalid-debt-accumulated-rate");
         _collateralPools[_collateralPoolId].debtAccumulatedRate = _debtAccumulatedRate;
         emit LogSetDebtAccumulatedRate(msg.sender, _collateralPoolId, _debtAccumulatedRate);
     }

--- a/scripts/tests/unit/config/CollateralPoolConfig.test.js
+++ b/scripts/tests/unit/config/CollateralPoolConfig.test.js
@@ -536,6 +536,21 @@ describe("CollateralPoolConfig", () => {
         ).to.be.revertedWith("!bookKeeperRole")
       })
     })
+    context("zero debt accumulated rate", () => {
+      it("should be revert", async () => {
+        await expect(
+          collateralPoolConfigAsAlice.setDebtAccumulatedRate(COLLATERAL_POOL_ID, 0)
+        ).to.be.revertedWith("CollateralPoolConfig/invalid-debt-accumulated-rate")
+      })
+    })
+    context("debt accumulated rate less then ray", () => {
+      it("should be revert", async () => {
+        await expect(
+          collateralPoolConfigAsAlice.setDebtAccumulatedRate(COLLATERAL_POOL_ID, WeiPerRay.sub(1))
+        ).to.be.revertedWith("CollateralPoolConfig/invalid-debt-accumulated-rate")
+      })
+    })
+
     context("when parameters are valid", () => {
       it("should success", async () => {
 


### PR DESCRIPTION
2.3.3 There are not enough checks in the setDebtAccumulatedRate function in CollateralPoolConfig - fixed, validation added