### PR TITLE
fix issue with onMoveCollateral calls in position manager, adjust tests

### DIFF
--- a/contracts/main/managers/PositionManager.sol
+++ b/contracts/main/managers/PositionManager.sol
@@ -289,7 +289,7 @@ contract PositionManager is PausableUpgradeable, IManager {
         );
         ICollateralPoolConfig _collateralPoolConfig = ICollateralPoolConfig(IBookKeeper(bookKeeper).collateralPoolConfig());
         IGenericTokenAdapter _tokenAdapter = IGenericTokenAdapter(_collateralPoolConfig.getAdapter(collateralPools[_positionId]));
-        _tokenAdapter.onMoveCollateral(positions[_positionId], _destination, _debtShare, abi.encode());
+        _tokenAdapter.onMoveCollateral(positions[_positionId], _destination, _lockedCollateral, abi.encode());
         emit LogExportPosition(_positionId, positions[_positionId], _destination, _lockedCollateral, _debtShare);
     }
 
@@ -312,7 +312,7 @@ contract PositionManager is PausableUpgradeable, IManager {
         );
         ICollateralPoolConfig _collateralPoolConfig = ICollateralPoolConfig(IBookKeeper(bookKeeper).collateralPoolConfig());
         IGenericTokenAdapter _tokenAdapter = IGenericTokenAdapter(_collateralPoolConfig.getAdapter(collateralPools[_positionId]));
-        _tokenAdapter.onMoveCollateral(_source, positions[_positionId], _debtShare, abi.encode());
+        _tokenAdapter.onMoveCollateral(_source, positions[_positionId], _lockedCollateral, abi.encode());
         emit LogImportPosition(_positionId, _source, positions[_positionId], _lockedCollateral, _debtShare);
     }
 
@@ -335,7 +335,7 @@ contract PositionManager is PausableUpgradeable, IManager {
         );
         ICollateralPoolConfig _collateralPoolConfig = ICollateralPoolConfig(IBookKeeper(bookKeeper).collateralPoolConfig());
         IGenericTokenAdapter _tokenAdapter = IGenericTokenAdapter(_collateralPoolConfig.getAdapter(collateralPools[_sourceId]));
-        _tokenAdapter.onMoveCollateral(positions[_sourceId], positions[_destinationId], _debtShare, abi.encode());
+        _tokenAdapter.onMoveCollateral(positions[_sourceId], positions[_destinationId], _lockedCollateral, abi.encode());
         emit LogMovePosition(_sourceId, _destinationId, _lockedCollateral, _debtShare);
     }
 

--- a/scripts/tests/unit/managers/PositionManager.test.js
+++ b/scripts/tests/unit/managers/PositionManager.test.js
@@ -537,12 +537,15 @@ describe("PositionManager", () => {
         })
         context("when Alice wants to export her own position to her own address", async () => {
             it("should be able to call exportPosition()", async () => {
-                await mockedTokenAdapter.mock.onMoveCollateral.returns()
-
                 await positionManager.open(formatBytes32String("WXDC"), AliceAddress)
                 const positionAddress = await positionManager.positions(1)
 
-                await mockedTokenAdapter.mock.onMoveCollateral.returns()
+                await mockedTokenAdapter.mock.onMoveCollateral.withArgs(
+                    positionAddress,
+                    AliceAddress,
+                    WeiPerWad.mul(2),
+                    []
+                ).returns()
                 await mockedBookKeeper.mock.positions.withArgs(
                     formatBytes32String("WXDC"),
                     positionAddress
@@ -566,7 +569,12 @@ describe("PositionManager", () => {
                 // Alice allows Bob to manage her position#1
                 await positionManagerAsAlice.allowManagePosition(1, BobAddress, 1)
 
-                await mockedTokenAdapter.mock.onMoveCollateral.returns()
+                await mockedTokenAdapter.mock.onMoveCollateral.withArgs(
+                    positionAddress,
+                    BobAddress,
+                    WeiPerWad.mul(2),
+                    []
+                ).returns()
                 await mockedBookKeeper.mock.positions.withArgs(
                     formatBytes32String("WXDC"),
                     positionAddress
@@ -604,7 +612,12 @@ describe("PositionManager", () => {
             it("should be able to call importPosition()", async () => {
                 await positionManager.open(formatBytes32String("WXDC"), AliceAddress)
                 const positionAddress = await positionManager.positions(1)
-                await mockedTokenAdapter.mock.onMoveCollateral.returns()
+                await mockedTokenAdapter.mock.onMoveCollateral.withArgs(
+                    AliceAddress,
+                    positionAddress,
+                    WeiPerWad.mul(2),
+                    []
+                ).returns()
                 await mockedBookKeeper.mock.positions.withArgs(
                     formatBytes32String("WXDC"),
                     AliceAddress
@@ -630,7 +643,12 @@ describe("PositionManager", () => {
                 // Alice gives Bob migration access on her address
                 await positionManagerAsAlice.allowMigratePosition(BobAddress, 1)
 
-                await mockedTokenAdapter.mock.onMoveCollateral.returns()
+                await mockedTokenAdapter.mock.onMoveCollateral.withArgs(
+                    BobAddress,
+                    positionAddress,
+                    WeiPerWad.mul(2),
+                    []
+                ).returns()
                 await mockedBookKeeper.mock.positions.withArgs(
                     formatBytes32String("WXDC"),
                     BobAddress
@@ -682,7 +700,12 @@ describe("PositionManager", () => {
                 const position1Address = await positionManager.positions(1)
                 const position2Address = await positionManager.positions(2)
 
-                await mockedTokenAdapter.mock.onMoveCollateral.returns()
+                await mockedTokenAdapter.mock.onMoveCollateral.withArgs(
+                    position1Address,
+                    position2Address,
+                    WeiPerWad.mul(2),
+                    []
+                ).returns()
                 await mockedBookKeeper.mock.positions.withArgs(
                     formatBytes32String("WXDC"),
                     position1Address
@@ -710,7 +733,12 @@ describe("PositionManager", () => {
                     formatBytes32String("WXDC"),
                     position1Address
                 ).returns(WeiPerWad.mul(2), WeiPerWad.mul(1))
-                await mockedTokenAdapter.mock.onMoveCollateral.returns()
+                await mockedTokenAdapter.mock.onMoveCollateral.withArgs(
+                    position1Address,
+                    position2Address,
+                    WeiPerWad.mul(2),
+                    []
+                ).returns()
                 await mockedBookKeeper.mock.movePosition.withArgs(
                     formatBytes32String("WXDC"),
                     position1Address,


### PR DESCRIPTION
2.3.2 importPosition , exportPosition and movePosition move _debtShare instead of _lockedCollateral in PositionManager - fixed, now we use _lockedCollateral instead of _debtShare