### PR TITLE
update poolStablecoinIssued variable on confiscatePosition and accrueStabilityFee calls

### DIFF
--- a/contracts/main/stablecoin-core/BookKeeper.sol
+++ b/contracts/main/stablecoin-core/BookKeeper.sol
@@ -372,6 +372,9 @@ contract BookKeeper is IBookKeeper, PausableUpgradeable, ReentrancyGuardUpgradea
 
         int256 _debtValue = mul(_vars.debtAccumulatedRate, _debtShare);
 
+        uint256 _poolStablecoinAmount = poolStablecoinIssued[_collateralPoolId];
+        poolStablecoinIssued[_collateralPoolId] = add(_poolStablecoinAmount, _debtValue);
+
         collateralToken[_collateralPoolId][_collateralCreditor] = sub(collateralToken[_collateralPoolId][_collateralCreditor], _collateralAmount);
         systemBadDebt[_stablecoinDebtor] = sub(systemBadDebt[_stablecoinDebtor], _debtValue);
         totalUnbackedStablecoin = sub(totalUnbackedStablecoin, _debtValue);
@@ -415,6 +418,10 @@ contract BookKeeper is IBookKeeper, PausableUpgradeable, ReentrancyGuardUpgradea
         _vars.debtAccumulatedRate = add(_vars.debtAccumulatedRate, _debtAccumulatedRate);
         ICollateralPoolConfig(collateralPoolConfig).setDebtAccumulatedRate(_collateralPoolId, _vars.debtAccumulatedRate);
         int256 _value = mul(_vars.totalDebtShare, _debtAccumulatedRate); // [rad]
+
+        uint256 _poolStablecoinAmount = poolStablecoinIssued[_collateralPoolId];
+        poolStablecoinIssued[_collateralPoolId] = add(_poolStablecoinAmount, _value);
+
         stablecoin[_stabilityFeeRecipient] = add(stablecoin[_stabilityFeeRecipient], _value);
         totalStablecoinIssued = add(totalStablecoinIssued, _value);
     }

--- a/scripts/tests/unit/stablecoin-core/BookKeeper.test.js
+++ b/scripts/tests/unit/stablecoin-core/BookKeeper.test.js
@@ -11,6 +11,7 @@ const { getContract, createMock } = require("../../helper/contracts");
 const { loadFixture } = require("../../helper/fixtures");
 
 const { formatBytes32String } = ethers.utils
+const COLLATERAL_POOL_ID = formatBytes32String("WXDC")
 
 const loadFixtureHandler = async () => {
     const mockedCollateralPoolConfig = await createMock("CollateralPoolConfig");
@@ -70,7 +71,7 @@ describe("BookKeeper", () => {
                 await mockedAccessControlConfig.mock.hasRole.returns(false)
 
                 await expect(
-                    bookKeeperAsAlice.addCollateral(formatBytes32String("WXDC"), DeployerAddress, WeiPerWad)
+                    bookKeeperAsAlice.addCollateral(COLLATERAL_POOL_ID, DeployerAddress, WeiPerWad)
                 ).to.be.revertedWith("!adapterRole")
             })
         })
@@ -83,12 +84,12 @@ describe("BookKeeper", () => {
                     // init WXDC collateral pool
                     await mockedCollateralPoolConfig.mock.getStabilityFeeRate.returns(WeiPerRay)
 
-                    const collateralTokenBefore = await bookKeeper.collateralToken(formatBytes32String("WXDC"), DeployerAddress)
+                    const collateralTokenBefore = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, DeployerAddress)
                     expect(collateralTokenBefore).to.be.equal(0)
 
-                    await bookKeeper.addCollateral(formatBytes32String("WXDC"), DeployerAddress, WeiPerWad, { gasLimit: 1000000 })
+                    await bookKeeper.addCollateral(COLLATERAL_POOL_ID, DeployerAddress, WeiPerWad, { gasLimit: 1000000 })
 
-                    const collateralTokenAfter = await bookKeeper.collateralToken(formatBytes32String("WXDC"), DeployerAddress)
+                    const collateralTokenAfter = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, DeployerAddress)
                     expect(collateralTokenAfter).to.be.equal(WeiPerWad)
                 })
             })
@@ -102,15 +103,15 @@ describe("BookKeeper", () => {
                     await mockedCollateralPoolConfig.mock.getStabilityFeeRate.returns(WeiPerRay)
 
                     // add collateral 1 WXDC
-                    await bookKeeper.addCollateral(formatBytes32String("WXDC"), DeployerAddress, WeiPerWad, { gasLimit: 1000000 })
+                    await bookKeeper.addCollateral(COLLATERAL_POOL_ID, DeployerAddress, WeiPerWad, { gasLimit: 1000000 })
 
-                    const collateralTokenBefore = await bookKeeper.collateralToken(formatBytes32String("WXDC"), DeployerAddress)
+                    const collateralTokenBefore = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, DeployerAddress)
                     expect(collateralTokenBefore).to.be.equal(WeiPerWad)
 
                     // add collateral -1 WXDC
-                    await bookKeeper.addCollateral(formatBytes32String("WXDC"), DeployerAddress, WeiPerWad.mul(-1), { gasLimit: 1000000 })
+                    await bookKeeper.addCollateral(COLLATERAL_POOL_ID, DeployerAddress, WeiPerWad.mul(-1), { gasLimit: 1000000 })
 
-                    const collateralTokenAfter = await bookKeeper.collateralToken(formatBytes32String("WXDC"), DeployerAddress)
+                    const collateralTokenAfter = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, DeployerAddress)
                     expect(collateralTokenAfter).to.be.equal(0)
                 })
             })
@@ -122,7 +123,7 @@ describe("BookKeeper", () => {
             it("should be revert", async () => {
                 // bob call move collateral from alice to bob
                 await await expect(
-                    bookKeeperAsBob.moveCollateral(formatBytes32String("WXDC"), AliceAddress, BobAddress, WeiPerWad, { gasLimit: 1000000 })
+                    bookKeeperAsBob.moveCollateral(COLLATERAL_POOL_ID, AliceAddress, BobAddress, WeiPerWad, { gasLimit: 1000000 })
                 ).to.be.revertedWith("BookKeeper/moveCollateral/not-allowed")
             })
 
@@ -131,22 +132,22 @@ describe("BookKeeper", () => {
                     await mockedAccessControlConfig.mock.hasRole.returns(true)
 
                     // add collateral 1 WXDC to alice
-                    await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad, { gasLimit: 1000000 })
+                    await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad, { gasLimit: 1000000 })
 
-                    const collateralTokenAliceBefore = await bookKeeper.collateralToken(formatBytes32String("WXDC"), AliceAddress)
+                    const collateralTokenAliceBefore = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, AliceAddress)
                     expect(collateralTokenAliceBefore).to.be.equal(WeiPerWad)
-                    const collateralTokenBobBefore = await bookKeeper.collateralToken(formatBytes32String("WXDC"), BobAddress)
+                    const collateralTokenBobBefore = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, BobAddress)
                     expect(collateralTokenBobBefore).to.be.equal(0)
 
                     // alice allow bob to move collateral
                     await bookKeeperAsAlice.whitelist(BobAddress)
 
                     // bob call move collateral from alice to bob
-                    await bookKeeperAsBob.moveCollateral(formatBytes32String("WXDC"), AliceAddress, BobAddress, WeiPerWad, { gasLimit: 1000000 })
+                    await bookKeeperAsBob.moveCollateral(COLLATERAL_POOL_ID, AliceAddress, BobAddress, WeiPerWad, { gasLimit: 1000000 })
 
-                    const collateralTokenAliceAfter = await bookKeeper.collateralToken(formatBytes32String("WXDC"), AliceAddress)
+                    const collateralTokenAliceAfter = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, AliceAddress)
                     expect(collateralTokenAliceAfter).to.be.equal(0)
-                    const collateralTokenBobAfter = await bookKeeper.collateralToken(formatBytes32String("WXDC"), BobAddress)
+                    const collateralTokenBobAfter = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, BobAddress)
                     expect(collateralTokenBobAfter).to.be.equal(WeiPerWad)
                 })
             })
@@ -157,7 +158,7 @@ describe("BookKeeper", () => {
                 it("shold be revert", async () => {
                     // alice call move collateral from alice to bob
                     await expect(
-                        bookKeeperAsAlice.moveCollateral(formatBytes32String("WXDC"), AliceAddress, BobAddress, WeiPerWad, { gasLimit: 1000000 })
+                        bookKeeperAsAlice.moveCollateral(COLLATERAL_POOL_ID, AliceAddress, BobAddress, WeiPerWad, { gasLimit: 1000000 })
                     ).to.be.reverted
                 })
             })
@@ -166,19 +167,19 @@ describe("BookKeeper", () => {
                     await mockedAccessControlConfig.mock.hasRole.returns(true)
 
                     // add collateral 1 WXDC to alice
-                    await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad, { gasLimit: 1000000 })
+                    await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad, { gasLimit: 1000000 })
 
-                    const collateralTokenAliceBefore = await bookKeeper.collateralToken(formatBytes32String("WXDC"), AliceAddress)
+                    const collateralTokenAliceBefore = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, AliceAddress)
                     expect(collateralTokenAliceBefore).to.be.equal(WeiPerWad)
-                    const collateralTokenBobBefore = await bookKeeper.collateralToken(formatBytes32String("WXDC"), BobAddress)
+                    const collateralTokenBobBefore = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, BobAddress)
                     expect(collateralTokenBobBefore).to.be.equal(0)
 
                     // move collateral 1 WXDC from alice to bob
-                    await bookKeeperAsAlice.moveCollateral(formatBytes32String("WXDC"), AliceAddress, BobAddress, WeiPerWad, { gasLimit: 1000000 })
+                    await bookKeeperAsAlice.moveCollateral(COLLATERAL_POOL_ID, AliceAddress, BobAddress, WeiPerWad, { gasLimit: 1000000 })
 
-                    const collateralTokenAliceAfter = await bookKeeper.collateralToken(formatBytes32String("WXDC"), AliceAddress)
+                    const collateralTokenAliceAfter = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, AliceAddress)
                     expect(collateralTokenAliceAfter).to.be.equal(0)
-                    const collateralTokenBobAfter = await bookKeeper.collateralToken(formatBytes32String("WXDC"), BobAddress)
+                    const collateralTokenBobAfter = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, BobAddress)
                     expect(collateralTokenBobAfter).to.be.equal(WeiPerWad)
                 })
             })
@@ -260,7 +261,7 @@ describe("BookKeeper", () => {
 
                 await expect(
                     bookKeeper.adjustPosition(
-                        formatBytes32String("WXDC"),
+                        COLLATERAL_POOL_ID,
                         DeployerAddress,
                         DeployerAddress,
                         DeployerAddress,
@@ -286,7 +287,7 @@ describe("BookKeeper", () => {
 
                 await expect(
                     bookKeeper.adjustPosition(
-                        formatBytes32String("WXDC"),
+                        COLLATERAL_POOL_ID,
                         DeployerAddress,
                         DeployerAddress,
                         DeployerAddress,
@@ -320,7 +321,7 @@ describe("BookKeeper", () => {
 
                         await expect(
                             bookKeeperAsAlice.adjustPosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 BobAddress,
                                 AliceAddress,
@@ -347,7 +348,7 @@ describe("BookKeeper", () => {
 
                                 await expect(
                                     bookKeeperAsAlice.adjustPosition(
-                                        formatBytes32String("WXDC"),
+                                        COLLATERAL_POOL_ID,
                                         AliceAddress,
                                         BobAddress,
                                         AliceAddress,
@@ -379,17 +380,17 @@ describe("BookKeeper", () => {
                                 })
 
                                 // add collateral to bob 10 WXDC
-                                await bookKeeper.addCollateral(formatBytes32String("WXDC"), BobAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                                await bookKeeper.addCollateral(COLLATERAL_POOL_ID, BobAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                                 // alice allow bob to move stablecoin
                                 await bookKeeperAsBob.whitelist(AliceAddress)
 
-                                const positionBefore = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                                const positionBefore = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                                 expect(positionBefore.lockedCollateral).to.be.equal(0)
 
                                 // lock collateral
                                 await bookKeeperAsAlice.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     AliceAddress,
                                     BobAddress,
                                     AliceAddress,
@@ -398,7 +399,7 @@ describe("BookKeeper", () => {
                                     { gasLimit: 1000000 }
                                 )
 
-                                const positionAfter = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                                const positionAfter = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                                 expect(positionAfter.lockedCollateral).to.be.equal(WeiPerWad.mul(10))
                             })
                         })
@@ -418,7 +419,7 @@ describe("BookKeeper", () => {
 
                             await expect(
                                 bookKeeperAsAlice.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     AliceAddress,
                                     AliceAddress,
                                     AliceAddress,
@@ -449,14 +450,14 @@ describe("BookKeeper", () => {
                             })
 
                             // add collateral to bob 10 WXDC
-                            await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                            await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
-                            const positionBefore = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                            const positionBefore = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                             expect(positionBefore.lockedCollateral).to.be.equal(0)
 
                             // lock collateral
                             await bookKeeperAsAlice.adjustPosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 AliceAddress,
                                 AliceAddress,
@@ -465,7 +466,7 @@ describe("BookKeeper", () => {
                                 { gasLimit: 1000000 }
                             )
 
-                            const positionAfter = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                            const positionAfter = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                             expect(positionAfter.lockedCollateral).to.be.equal(WeiPerWad.mul(10))
                         })
                     })
@@ -487,7 +488,7 @@ describe("BookKeeper", () => {
                             // free collateral
                             await expect(
                                 bookKeeperAsAlice.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     AliceAddress,
                                     AliceAddress,
                                     AliceAddress,
@@ -519,11 +520,11 @@ describe("BookKeeper", () => {
                             })
 
                             // add collateral to alice 10 WXDC
-                            await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                            await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                             // lock collateral
                             await bookKeeperAsAlice.adjustPosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 AliceAddress,
                                 AliceAddress,
@@ -532,17 +533,17 @@ describe("BookKeeper", () => {
                                 { gasLimit: 1000000 }
                             )
 
-                            const positionAliceBefore = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                            const positionAliceBefore = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                             expect(positionAliceBefore.lockedCollateral).to.be.equal(WeiPerWad.mul(10))
                             const collateralTokenAliceBefore = await bookKeeper.collateralToken(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress
                             )
                             expect(collateralTokenAliceBefore).to.be.equal(0)
 
                             // free collateral
                             await bookKeeperAsAlice.adjustPosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 AliceAddress,
                                 AliceAddress,
@@ -550,10 +551,10 @@ describe("BookKeeper", () => {
                                 0
                             )
 
-                            const positionAliceAfter = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                            const positionAliceAfter = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                             expect(positionAliceAfter.lockedCollateral).to.be.equal(WeiPerWad.mul(9))
                             const collateralTokenAliceAfter = await bookKeeper.collateralToken(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress
                             )
                             expect(collateralTokenAliceAfter).to.be.equal(WeiPerWad)
@@ -575,7 +576,7 @@ describe("BookKeeper", () => {
                             // free collateral
                             await expect(
                                 bookKeeperAsAlice.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     AliceAddress,
                                     BobAddress,
                                     AliceAddress,
@@ -607,11 +608,11 @@ describe("BookKeeper", () => {
                             })
 
                             // add collateral to alice 10 WXDC
-                            await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                            await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                             // lock collateral
                             await bookKeeperAsAlice.adjustPosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 AliceAddress,
                                 AliceAddress,
@@ -620,14 +621,14 @@ describe("BookKeeper", () => {
                                 { gasLimit: 1000000 }
                             )
 
-                            const positionAliceBefore = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                            const positionAliceBefore = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                             expect(positionAliceBefore.lockedCollateral).to.be.equal(WeiPerWad.mul(10))
-                            const collateralTokenBobBefore = await bookKeeper.collateralToken(formatBytes32String("WXDC"), BobAddress)
+                            const collateralTokenBobBefore = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, BobAddress)
                             expect(collateralTokenBobBefore).to.be.equal(0)
 
                             // free collateral
                             await bookKeeperAsAlice.adjustPosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 BobAddress,
                                 AliceAddress,
@@ -636,9 +637,9 @@ describe("BookKeeper", () => {
                                 { gasLimit: 1000000 }
                             )
 
-                            const positionAliceAfter = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                            const positionAliceAfter = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                             expect(positionAliceAfter.lockedCollateral).to.be.equal(WeiPerWad.mul(9))
-                            const collateralTokenBobAfter = await bookKeeper.collateralToken(formatBytes32String("WXDC"), BobAddress)
+                            const collateralTokenBobAfter = await bookKeeper.collateralToken(COLLATERAL_POOL_ID, BobAddress)
                             expect(collateralTokenBobAfter).to.be.equal(WeiPerWad)
                         })
                     })
@@ -671,7 +672,7 @@ describe("BookKeeper", () => {
 
                             await expect(
                                 bookKeeper.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     DeployerAddress,
                                     DeployerAddress,
                                     DeployerAddress,
@@ -706,7 +707,7 @@ describe("BookKeeper", () => {
 
                             await expect(
                                 bookKeeper.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     DeployerAddress,
                                     DeployerAddress,
                                     DeployerAddress,
@@ -742,7 +743,7 @@ describe("BookKeeper", () => {
 
                         await expect(
                             bookKeeper.adjustPosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 DeployerAddress,
                                 DeployerAddress,
                                 DeployerAddress,
@@ -777,11 +778,11 @@ describe("BookKeeper", () => {
                             await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                             // add collateral to 10 WXDC
-                            await bookKeeper.addCollateral(formatBytes32String("WXDC"), BobAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                            await bookKeeper.addCollateral(COLLATERAL_POOL_ID, BobAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                             // bob lock collateral 10 WXDC
                             await bookKeeperAsBob.adjustPosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 BobAddress,
                                 BobAddress,
                                 BobAddress,
@@ -792,7 +793,7 @@ describe("BookKeeper", () => {
 
                             await expect(
                                 bookKeeperAsAlice.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     BobAddress,
                                     BobAddress,
                                     BobAddress,
@@ -826,11 +827,11 @@ describe("BookKeeper", () => {
                                 await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                                 // add collateral to 10 WXDC
-                                await bookKeeper.addCollateral(formatBytes32String("WXDC"), BobAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                                await bookKeeper.addCollateral(COLLATERAL_POOL_ID, BobAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                                 // bob lock collateral 10 WXDC
                                 await bookKeeperAsBob.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     BobAddress,
                                     BobAddress,
                                     BobAddress,
@@ -839,7 +840,7 @@ describe("BookKeeper", () => {
                                     { gasLimit: 1000000 }
                                 )
 
-                                const positionBobBefore = await bookKeeper.positions(formatBytes32String("WXDC"), BobAddress)
+                                const positionBobBefore = await bookKeeper.positions(COLLATERAL_POOL_ID, BobAddress)
                                 expect(positionBobBefore.debtShare).to.be.equal(0)
 
                                 const stablecoinAliceBefore = await bookKeeper.stablecoin(AliceAddress)
@@ -850,7 +851,7 @@ describe("BookKeeper", () => {
 
                                 // alice draw
                                 await bookKeeperAsAlice.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     BobAddress,
                                     BobAddress,
                                     AliceAddress,
@@ -859,7 +860,7 @@ describe("BookKeeper", () => {
                                     { gasLimit: 1000000 }
                                 );
 
-                                const positionBobAfter = await bookKeeper.positions(formatBytes32String("WXDC"), BobAddress)
+                                const positionBobAfter = await bookKeeper.positions(COLLATERAL_POOL_ID, BobAddress)
                                 expect(positionBobAfter.debtShare).to.be.equal(WeiPerWad.mul(10))
 
                                 const stablecoinAliceAfter = await bookKeeper.stablecoin(AliceAddress)
@@ -889,11 +890,11 @@ describe("BookKeeper", () => {
                             await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                             // add collateral to 10 WXDC
-                            await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                            await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                             // alice lock collateral 10 WXDC
                             await bookKeeperAsAlice.adjustPosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 AliceAddress,
                                 AliceAddress,
@@ -902,7 +903,7 @@ describe("BookKeeper", () => {
                                 { gasLimit: 1000000 }
                             )
 
-                            const positionaliceBefore = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                            const positionaliceBefore = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                             expect(positionaliceBefore.debtShare).to.be.equal(0)
 
                             const stablecoinAliceBefore = await bookKeeper.stablecoin(AliceAddress)
@@ -910,7 +911,7 @@ describe("BookKeeper", () => {
 
                             // alice draw
                             await bookKeeperAsAlice.adjustPosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 AliceAddress,
                                 AliceAddress,
@@ -919,7 +920,7 @@ describe("BookKeeper", () => {
                                 { gasLimit: 1000000 }
                             )
 
-                            const positionaliceAfter = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                            const positionaliceAfter = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                             expect(positionaliceAfter.debtShare).to.be.equal(WeiPerWad.mul(10))
                             const stablecoinAliceAfter = await bookKeeper.stablecoin(AliceAddress)
                             expect(stablecoinAliceAfter).to.be.equal(WeiPerRad.mul(10))
@@ -946,11 +947,11 @@ describe("BookKeeper", () => {
                             await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                             // add collateral to 10 WXDC
-                            await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                            await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                             // alice lock collateral 10 WXDC
                             await bookKeeperAsAlice.adjustPosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 AliceAddress,
                                 AliceAddress,
@@ -962,7 +963,7 @@ describe("BookKeeper", () => {
                             // alice draw
                             await expect(
                                 bookKeeperAsAlice.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     AliceAddress,
                                     AliceAddress,
                                     AliceAddress,
@@ -995,11 +996,11 @@ describe("BookKeeper", () => {
                                 await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                                 // add collateral to 10 WXDC
-                                await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                                await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                                 // alice lock collateral 10 WXDC
                                 await bookKeeperAsAlice.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     AliceAddress,
                                     AliceAddress,
                                     AliceAddress,
@@ -1010,7 +1011,7 @@ describe("BookKeeper", () => {
 
                                 // alice draw
                                 await bookKeeperAsAlice.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     AliceAddress,
                                     AliceAddress,
                                     AliceAddress,
@@ -1019,7 +1020,7 @@ describe("BookKeeper", () => {
                                     { gasLimit: 1000000 }
                                 )
 
-                                const positionaliceBefore = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                                const positionaliceBefore = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                                 expect(positionaliceBefore.debtShare).to.be.equal(WeiPerWad.mul(10))
                                 const stablecoinAliceBefore = await bookKeeper.stablecoin(AliceAddress)
                                 expect(stablecoinAliceBefore).to.be.equal(WeiPerRad.mul(10))
@@ -1033,7 +1034,7 @@ describe("BookKeeper", () => {
                                 })
                                 // alice wipe
                                 await bookKeeperAsAlice.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     AliceAddress,
                                     AliceAddress,
                                     AliceAddress,
@@ -1042,7 +1043,7 @@ describe("BookKeeper", () => {
                                     { gasLimit: 1000000 }
                                 )
 
-                                const positionaliceAfter = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                                const positionaliceAfter = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                                 expect(positionaliceAfter.debtShare).to.be.equal(0)
 
                                 const stablecoinAliceAfter = await bookKeeper.stablecoin(AliceAddress)
@@ -1070,11 +1071,11 @@ describe("BookKeeper", () => {
                                 await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                                 // add collateral to 10 WXDC
-                                await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                                await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                                 // alice lock collateral 10 WXDC
                                 await bookKeeperAsAlice.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     AliceAddress,
                                     AliceAddress,
                                     AliceAddress,
@@ -1085,7 +1086,7 @@ describe("BookKeeper", () => {
 
                                 // alice draw
                                 await bookKeeperAsAlice.adjustPosition(
-                                    formatBytes32String("WXDC"),
+                                    COLLATERAL_POOL_ID,
                                     AliceAddress,
                                     AliceAddress,
                                     AliceAddress,
@@ -1104,7 +1105,7 @@ describe("BookKeeper", () => {
                                 // alice wipe
                                 await expect(
                                     bookKeeperAsAlice.adjustPosition(
-                                        formatBytes32String("WXDC"),
+                                        COLLATERAL_POOL_ID,
                                         AliceAddress,
                                         AliceAddress,
                                         AliceAddress,
@@ -1143,11 +1144,11 @@ describe("BookKeeper", () => {
                     await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                     // add collateral to 10 WXDC
-                    await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                    await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                     // alice lock collateral 10 WXDC
                     await bookKeeperAsAlice.adjustPosition(
-                        formatBytes32String("WXDC"),
+                        COLLATERAL_POOL_ID,
                         AliceAddress,
                         AliceAddress,
                         AliceAddress,
@@ -1158,7 +1159,7 @@ describe("BookKeeper", () => {
 
                     await expect(
                         bookKeeperAsAlice.movePosition(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             AliceAddress,
                             BobAddress,
                             WeiPerWad.mul(5),
@@ -1189,11 +1190,11 @@ describe("BookKeeper", () => {
                         await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                         // add collateral to 10 WXDC
-                        await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                        await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                         // alice lock collateral 10 WXDC
                         await bookKeeperAsAlice.adjustPosition(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             AliceAddress,
                             AliceAddress,
                             AliceAddress,
@@ -1207,7 +1208,7 @@ describe("BookKeeper", () => {
 
                         await expect(
                             bookKeeperAsAlice.movePosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 BobAddress,
                                 WeiPerWad.mul(10),
@@ -1237,11 +1238,11 @@ describe("BookKeeper", () => {
                         await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                         // add collateral to 10 WXDC
-                        await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                        await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                         // alice lock collateral 10 WXDC
                         await bookKeeperAsAlice.adjustPosition(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             AliceAddress,
                             AliceAddress,
                             AliceAddress,
@@ -1255,7 +1256,7 @@ describe("BookKeeper", () => {
 
                         await expect(
                             bookKeeperAsAlice.movePosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 BobAddress,
                                 WeiPerWad.mul(0),
@@ -1285,11 +1286,11 @@ describe("BookKeeper", () => {
                         await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                         // add collateral to 10 WXDC
-                        await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                        await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                         // alice lock collateral 10 WXDC
                         await bookKeeperAsAlice.adjustPosition(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             AliceAddress,
                             AliceAddress,
                             AliceAddress,
@@ -1303,7 +1304,7 @@ describe("BookKeeper", () => {
 
                         await expect(
                             bookKeeperAsAlice.movePosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 BobAddress,
                                 WeiPerWad.mul(5),
@@ -1333,11 +1334,11 @@ describe("BookKeeper", () => {
                         await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                         // add collateral to 10 WXDC
-                        await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                        await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                         // alice lock collateral 10 WXDC
                         await bookKeeperAsAlice.adjustPosition(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             AliceAddress,
                             AliceAddress,
                             AliceAddress,
@@ -1351,7 +1352,7 @@ describe("BookKeeper", () => {
 
                         await expect(
                             bookKeeperAsAlice.movePosition(
-                                formatBytes32String("WXDC"),
+                                COLLATERAL_POOL_ID,
                                 AliceAddress,
                                 BobAddress,
                                 WeiPerWad.mul(5),
@@ -1381,11 +1382,11 @@ describe("BookKeeper", () => {
                         await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                         // add collateral to 10 WXDC
-                        await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
+                        await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(10), { gasLimit: 1000000 })
 
                         // alice lock collateral 10 WXDC
                         await bookKeeperAsAlice.adjustPosition(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             AliceAddress,
                             AliceAddress,
                             AliceAddress,
@@ -1397,27 +1398,27 @@ describe("BookKeeper", () => {
                         // bob allow alice to manage a position
                         await bookKeeperAsBob.whitelist(AliceAddress)
 
-                        const positionAliceBefore = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                        const positionAliceBefore = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                         expect(positionAliceBefore.lockedCollateral).to.be.equal(WeiPerWad.mul(10))
                         expect(positionAliceBefore.debtShare).to.be.equal(WeiPerWad.mul(2))
 
-                        const positionBobBefore = await bookKeeper.positions(formatBytes32String("WXDC"), BobAddress)
+                        const positionBobBefore = await bookKeeper.positions(COLLATERAL_POOL_ID, BobAddress)
                         expect(positionBobBefore.lockedCollateral).to.be.equal(0)
                         expect(positionBobBefore.debtShare).to.be.equal(0)
 
                         await bookKeeperAsAlice.movePosition(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             AliceAddress,
                             BobAddress,
                             WeiPerWad.mul(5),
                             WeiPerWad.mul(1)
                         )
 
-                        const positionAliceAfter = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                        const positionAliceAfter = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                         expect(positionAliceAfter.lockedCollateral).to.be.equal(WeiPerWad.mul(5))
                         expect(positionAliceAfter.debtShare).to.be.equal(WeiPerWad.mul(1))
 
-                        const positionBobAfter = await bookKeeper.positions(formatBytes32String("WXDC"), BobAddress)
+                        const positionBobAfter = await bookKeeper.positions(COLLATERAL_POOL_ID, BobAddress)
                         expect(positionBobAfter.lockedCollateral).to.be.equal(WeiPerWad.mul(5))
                         expect(positionBobAfter.debtShare).to.be.equal(WeiPerWad.mul(1))
                     })
@@ -1432,7 +1433,7 @@ describe("BookKeeper", () => {
                 await mockedAccessControlConfig.mock.hasRole.returns(false)
                 await expect(
                     bookKeeperAsAlice.confiscatePosition(
-                        formatBytes32String("WXDC"),
+                        COLLATERAL_POOL_ID,
                         AliceAddress,
                         DeployerAddress,
                         DeployerAddress,
@@ -1467,10 +1468,10 @@ describe("BookKeeper", () => {
                         await bookKeeper.setTotalDebtCeiling(WeiPerRad, { gasLimit: 1000000 })
 
                         // add collateral to 1 WXDC
-                        await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad, { gasLimit: 1000000 })
+                        await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad, { gasLimit: 1000000 })
                         // adjust position
                         await bookKeeperAsAlice.adjustPosition(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             AliceAddress,
                             AliceAddress,
                             AliceAddress,
@@ -1479,11 +1480,11 @@ describe("BookKeeper", () => {
                             { gasLimit: 1000000 }
                         )
 
-                        const positionBefore = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                        const positionBefore = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                         expect(positionBefore.lockedCollateral).to.be.equal(WeiPerWad)
                         expect(positionBefore.debtShare).to.be.equal(WeiPerWad)
                         const collateralTokenCreditorBefore = await bookKeeper.collateralToken(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             DeployerAddress
                         )
                         expect(collateralTokenCreditorBefore).to.be.equal(0)
@@ -1491,6 +1492,8 @@ describe("BookKeeper", () => {
                         expect(systemBadDebtDebtorBefore).to.be.equal(0)
                         const totalUnbackedStablecoinBefore = await bookKeeper.totalUnbackedStablecoin()
                         expect(totalUnbackedStablecoinBefore).to.be.equal(0)
+                        const poolStablecoinIssuedBefore = await bookKeeper.poolStablecoinIssued(COLLATERAL_POOL_ID)
+                        expect(poolStablecoinIssuedBefore).to.be.equal(WeiPerRad)
                         await mockedCollateralPoolConfig.mock.getTotalDebtShare.returns(WeiPerWad.mul(1))
                         await mockedCollateralPoolConfig.mock.getCollateralPoolInfo.returns({
                             debtAccumulatedRate: WeiPerRay,
@@ -1501,7 +1504,7 @@ describe("BookKeeper", () => {
                         })
                         // confiscate position
                         await bookKeeper.confiscatePosition(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             AliceAddress,
                             DeployerAddress,
                             DeployerAddress,
@@ -1510,11 +1513,11 @@ describe("BookKeeper", () => {
                             { gasLimit: 1000000 }
                         )
 
-                        const positionAfter = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                        const positionAfter = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                         expect(positionAfter.lockedCollateral).to.be.equal(0)
                         expect(positionAfter.debtShare).to.be.equal(0)
                         const collateralTokenCreditorAfter = await bookKeeper.collateralToken(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             DeployerAddress
                         )
                         expect(collateralTokenCreditorAfter).to.be.equal(WeiPerWad)
@@ -1522,6 +1525,8 @@ describe("BookKeeper", () => {
                         expect(systemBadDebtDebtorAfter).to.be.equal(WeiPerRad)
                         const totalUnbackedStablecoinAfter = await bookKeeper.totalUnbackedStablecoin()
                         expect(totalUnbackedStablecoinAfter).to.be.equal(WeiPerRad)
+                        const poolStablecoinIssuedAfter = await bookKeeper.poolStablecoinIssued(COLLATERAL_POOL_ID)
+                        expect(poolStablecoinIssuedAfter).to.be.equal(0)
                     })
                 })
                 context("when liquidating some in position", () => {
@@ -1546,10 +1551,10 @@ describe("BookKeeper", () => {
                         await bookKeeper.setTotalDebtCeiling(WeiPerRad.mul(10), { gasLimit: 1000000 })
 
                         // add collateral to 2 WXDC
-                        await bookKeeper.addCollateral(formatBytes32String("WXDC"), AliceAddress, WeiPerWad.mul(2), { gasLimit: 1000000 })
+                        await bookKeeper.addCollateral(COLLATERAL_POOL_ID, AliceAddress, WeiPerWad.mul(2), { gasLimit: 1000000 })
                         // adjust position
                         await bookKeeperAsAlice.adjustPosition(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             AliceAddress,
                             AliceAddress,
                             AliceAddress,
@@ -1558,11 +1563,11 @@ describe("BookKeeper", () => {
                             { gasLimit: 1000000 }
                         )
 
-                        const positionBefore = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                        const positionBefore = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                         expect(positionBefore.lockedCollateral).to.be.equal(WeiPerWad.mul(2))
                         expect(positionBefore.debtShare).to.be.equal(WeiPerWad.mul(2))
                         const collateralTokenCreditorBefore = await bookKeeper.collateralToken(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             DeployerAddress
                         )
                         expect(collateralTokenCreditorBefore).to.be.equal(0)
@@ -1580,7 +1585,7 @@ describe("BookKeeper", () => {
                         })
                         // confiscate position
                         await bookKeeper.confiscatePosition(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             AliceAddress,
                             DeployerAddress,
                             DeployerAddress,
@@ -1589,11 +1594,11 @@ describe("BookKeeper", () => {
                             { gasLimit: 1000000 }
                         )
 
-                        const positionAfter = await bookKeeper.positions(formatBytes32String("WXDC"), AliceAddress)
+                        const positionAfter = await bookKeeper.positions(COLLATERAL_POOL_ID, AliceAddress)
                         expect(positionAfter.lockedCollateral).to.be.equal(WeiPerWad)
                         expect(positionAfter.debtShare).to.be.equal(WeiPerWad)
                         const collateralTokenCreditorAfter = await bookKeeper.collateralToken(
-                            formatBytes32String("WXDC"),
+                            COLLATERAL_POOL_ID,
                             DeployerAddress
                         )
                         expect(collateralTokenCreditorAfter).to.be.equal(WeiPerWad)
@@ -1684,7 +1689,7 @@ describe("BookKeeper", () => {
                 await mockedAccessControlConfig.mock.hasRole.returns(false)
 
                 await expect(
-                    bookKeeperAsAlice.accrueStabilityFee(formatBytes32String("WXDC"), DeployerAddress, WeiPerRay, { gasLimit: 1000000 })
+                    bookKeeperAsAlice.accrueStabilityFee(COLLATERAL_POOL_ID, DeployerAddress, WeiPerRay, { gasLimit: 1000000 })
                 ).to.be.revertedWith("!stabilityFeeCollectorRole")
             })
         })
@@ -1696,7 +1701,7 @@ describe("BookKeeper", () => {
                     await bookKeeper.cage()
 
                     await expect(
-                        bookKeeper.accrueStabilityFee(formatBytes32String("WXDC"), DeployerAddress, WeiPerRay, { gasLimit: 1000000 })
+                        bookKeeper.accrueStabilityFee(COLLATERAL_POOL_ID, DeployerAddress, WeiPerRay, { gasLimit: 1000000 })
                     ).to.be.revertedWith("BookKeeper/not-live")
                 })
             })
@@ -1722,10 +1727,10 @@ describe("BookKeeper", () => {
                     await bookKeeper.setTotalDebtCeiling(WeiPerRad, { gasLimit: 1000000 })
 
                     // add collateral to 1 WXDC
-                    await bookKeeper.addCollateral(formatBytes32String("WXDC"), DeployerAddress, WeiPerWad, { gasLimit: 1000000 })
+                    await bookKeeper.addCollateral(COLLATERAL_POOL_ID, DeployerAddress, WeiPerWad, { gasLimit: 1000000 })
                     // adjust position
                     await bookKeeper.adjustPosition(
-                        formatBytes32String("WXDC"),
+                        COLLATERAL_POOL_ID,
                         DeployerAddress,
                         DeployerAddress,
                         DeployerAddress,
@@ -1738,6 +1743,8 @@ describe("BookKeeper", () => {
                     expect(stablecoinDeployerBefore).to.be.equal(WeiPerRad)
                     const totalStablecoinIssuedBefore = await bookKeeper.totalStablecoinIssued()
                     expect(totalStablecoinIssuedBefore).to.be.equal(WeiPerRad)
+                    const poolStablecoinIssuedBefore = await bookKeeper.poolStablecoinIssued(COLLATERAL_POOL_ID)
+                    expect(poolStablecoinIssuedBefore).to.be.equal(WeiPerRad)
 
                     await mockedCollateralPoolConfig.mock.getTotalDebtShare.returns(WeiPerWad.mul(1))
                     await mockedCollateralPoolConfig.mock.getCollateralPoolInfo.returns({
@@ -1748,12 +1755,14 @@ describe("BookKeeper", () => {
                         debtFloor: WeiPerRad.mul(1),
                     })
 
-                    await bookKeeper.accrueStabilityFee(formatBytes32String("WXDC"), DeployerAddress, WeiPerRay, { gasLimit: 1000000 })
+                    await bookKeeper.accrueStabilityFee(COLLATERAL_POOL_ID, DeployerAddress, WeiPerRay, { gasLimit: 1000000 })
 
                     const stablecoinDeployerAfter = await bookKeeper.stablecoin(DeployerAddress)
                     expect(stablecoinDeployerAfter).to.be.equal(WeiPerRad.mul(2))
                     const totalStablecoinIssuedAfter = await bookKeeper.totalStablecoinIssued()
                     expect(totalStablecoinIssuedAfter).to.be.equal(WeiPerRad.mul(2))
+                    const poolStablecoinIssuedAfter = await bookKeeper.poolStablecoinIssued(COLLATERAL_POOL_ID)
+                    expect(poolStablecoinIssuedAfter).to.be.equal(WeiPerRad.mul(2))
                 })
             })
         })


### PR DESCRIPTION
2.3.5 The settleSystemBadDebt, mintUnbackedStablecoin, and accrueStabilityFee methods do not operate with the poolStablecoinIssued variable in BookKeeper - fixed. 

Issued unbacked stablecoins shouldn't be considered pool-issued stablecoins, since they aren't bound to any pool (not backed by any collateral). Therefore, we don't need to calculate poolStablecoinIssued in settleSystemBadDebt, mintUnbackedStablecoin.

poolStablecoinIssued calculation was added to confiscate position and accrueStabilityFee because they deal with stablecoins bound to a particular pool.