### PR TITLE
make setOwner function accessible only by owner

### DIFF
--- a/contracts/main/proxy-wallet/FathomAuth.sol
+++ b/contracts/main/proxy-wallet/FathomAuth.sol
@@ -17,7 +17,7 @@ contract FathomAuth is FathomAuthEvents {
         emit LogSetOwner(msg.sender);
     }
 
-    function setOwner(address _owner) external auth {
+    function setOwner(address _owner) external onlyOwner {
         owner = _owner;
         emit LogSetOwner(owner);
     }
@@ -29,6 +29,11 @@ contract FathomAuth is FathomAuthEvents {
 
     modifier auth() {
         require(isAuthorized(msg.sender, msg.sig), "fathom-auth-unauthorized");
+        _;
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "only owner allowed");
         _;
     }
 


### PR DESCRIPTION
2.3.6 Compromised authority may change owner of ProxyWallet - fixed. onlyOwner modifier added to setOwner function