### PR TITLE
don't allow zero stability fee rate

### DIFF
--- a/contracts/main/stablecoin-core/StabilityFeeCollector.sol
+++ b/contracts/main/stablecoin-core/StabilityFeeCollector.sol
@@ -20,7 +20,6 @@ contract StabilityFeeCollector is PausableUpgradeable, ReentrancyGuardUpgradeabl
 
     IBookKeeper public bookKeeper;
     address public systemDebtEngine;
-    uint256 public globalStabilityFeeRate; // Global, per-second stability fee debtAccumulatedRate [ray]
 
     function initialize(address _bookKeeper, address _systemDebtEngine) external initializer {
         PausableUpgradeable.__Pausable_init();
@@ -101,7 +100,6 @@ contract StabilityFeeCollector is PausableUpgradeable, ReentrancyGuardUpgradeabl
     }
 
     // --- Administration ---
-    event LogSetGlobalStabilityFeeRate(address indexed _caller, uint256 _data);
     event LogSetSystemDebtEngine(address indexed _caller, address _data);
 
     modifier onlyOwner() {
@@ -143,7 +141,7 @@ contract StabilityFeeCollector is PausableUpgradeable, ReentrancyGuardUpgradeabl
         require(systemDebtEngine != address(0), "StabilityFeeCollector/system-debt-engine-not-set");
 
         _debtAccumulatedRate = rmul(
-            rpow(add(globalStabilityFeeRate, _stabilityFeeRate), block.timestamp - _lastAccumulationTime, RAY),
+            rpow(_stabilityFeeRate, block.timestamp - _lastAccumulationTime, RAY),
             _previousDebtAccumulatedRate
         );
 

--- a/contracts/main/stablecoin-core/config/CollateralPoolConfig.sol
+++ b/contracts/main/stablecoin-core/config/CollateralPoolConfig.sol
@@ -82,7 +82,7 @@ contract CollateralPoolConfig is AccessControlUpgradeable, ICollateralPoolConfig
         _collateralPools[_collateralPoolId].priceFeed = _priceFeed;
         require(_liquidationRatio >= RAY, "CollateralPoolConfig/invalid-liquidation-ratio");
         _collateralPools[_collateralPoolId].liquidationRatio = _liquidationRatio;
-        require(_stabilityFeeRate == 0 || _stabilityFeeRate >= RAY, "CollateralPoolConfig/invalid-stability-fee-rate");
+        require(_stabilityFeeRate >= RAY, "CollateralPoolConfig/invalid-stability-fee-rate");
         // Maximum stability fee rate is 50% yearly
         require(_stabilityFeeRate <= 1000000012857214317438491659, "CollateralPoolConfig/stability-fee-rate-too-large");
         _collateralPools[_collateralPoolId].stabilityFeeRate = _stabilityFeeRate;
@@ -148,7 +148,7 @@ contract CollateralPoolConfig is AccessControlUpgradeable, ICollateralPoolConfig
     The above `stabilityFeeRate` will be the value we will use in this contract.
   */
     function setStabilityFeeRate(bytes32 _collateralPool, uint256 _stabilityFeeRate) external onlyOwner {
-        require(_stabilityFeeRate == 0 || _stabilityFeeRate >= RAY, "CollateralPoolConfig/invalid-stability-fee-rate");
+        require(_stabilityFeeRate >= RAY, "CollateralPoolConfig/invalid-stability-fee-rate");
         // Maximum stability fee rate is 50% yearly
         require(_stabilityFeeRate <= 1000000012857214317438491659, "CollateralPoolConfig/stability-fee-rate-too-large");
         _collateralPools[_collateralPool].stabilityFeeRate = _stabilityFeeRate;

--- a/scripts/tests/unit/config/CollateralPoolConfig.test.js
+++ b/scripts/tests/unit/config/CollateralPoolConfig.test.js
@@ -386,6 +386,13 @@ describe("CollateralPoolConfig", () => {
         )
       })
     })
+    context("when stability fee rate is zero", () => {
+      it("should be revert", async () => {
+        await expect(collateralPoolConfig.setStabilityFeeRate(COLLATERAL_POOL_ID, 0)).to.be.revertedWith(
+          "CollateralPoolConfig/invalid-stability-fee-rate"
+        )
+      })
+    })
     context("when stability fee rate too large", () => {
       it("should be revert", async () => {
         await expect(collateralPoolConfig.setStabilityFeeRate(COLLATERAL_POOL_ID, WeiPerRad)).to.be.revertedWith(

--- a/scripts/tests/unit/stablecoin-core/StabilityFeeCollector.test.js
+++ b/scripts/tests/unit/stablecoin-core/StabilityFeeCollector.test.js
@@ -97,31 +97,6 @@ describe("StabilityFeeCollector", () => {
         })
     })
 
-    describe("#setGlobalStabilityFeeRate", () => {
-        context("when the caller is not the owner", async () => {
-            xit("should revert", async () => {
-                await mockedBookKeeper.mock.collateralPoolConfig.returns(mockedCollateralPoolConfig.address)
-                await mockedBookKeeper.mock.accessControlConfig.returns(mockedAccessControlConfig.address)
-                await mockedAccessControlConfig.mock.hasRole.returns(false)
-
-                await expect(stabilityFeeCollectorAsAlice.setGlobalStabilityFeeRate(UnitHelpers.WeiPerWad)).to.be.revertedWith(
-                    "!ownerRole"
-                )
-            })
-        })
-        context("when the caller is the owner", async () => {
-            xit("should be able to call setGlobalStabilityFeeRate", async () => {
-                await mockedBookKeeper.mock.collateralPoolConfig.returns(mockedCollateralPoolConfig.address)
-                await mockedBookKeeper.mock.accessControlConfig.returns(mockedAccessControlConfig.address)
-                await mockedAccessControlConfig.mock.hasRole.returns(true)
-
-                await expect(stabilityFeeCollector.setGlobalStabilityFeeRate(UnitHelpers.WeiPerRay))
-                    .to.emit(stabilityFeeCollector, "LogSetGlobalStabilityFeeRate")
-                    .withArgs(DeployerAddress, UnitHelpers.WeiPerRay)
-            })
-        })
-    })
-
     describe("#setSystemDebtEngine", () => {
         context("when the caller is not the owner", async () => {
             it("should revert", async () => {


### PR DESCRIPTION
2.3.9 Zero stabilityFee blocks the collect function in StabilityFeeCollector - fixed, now we don't allow zero stabilityFee.