### PR TITLE
2.4.38 Using a hard-coded access role instead of reference to _accessControlConfig in FixedSpreadLiquidationStrategy

### DIFF
--- a/contracts/main/stablecoin-core/liquidation-strategies/FixedSpreadLiquidationStrategy.sol
+++ b/contracts/main/stablecoin-core/liquidation-strategies/FixedSpreadLiquidationStrategy.sol
@@ -155,9 +155,11 @@ contract FixedSpreadLiquidationStrategy is FixedSpreadLiquidationStrategyMath, P
         bytes calldata _data // Data to pass in external call; if length 0, no call is done
     ) external override nonReentrant whenNotPaused {
         require(
-            IAccessControlConfig(bookKeeper.accessControlConfig()).hasRole(keccak256("LIQUIDATION_ENGINE_ROLE"), msg.sender),
+            IAccessControlConfig(bookKeeper.accessControlConfig()).hasRole(
+                IAccessControlConfig(bookKeeper.accessControlConfig()).LIQUIDATION_ENGINE_ROLE(), msg.sender),
             "!liquidationEngingRole"
         );
+        
         require(_positionDebtShare > 0, "FixedSpreadLiquidationStrategy/zero-debt");
         require(_positionCollateralAmount > 0, "FixedSpreadLiquidationStrategy/zero-collateral-amount");
         require(_positionAddress != address(0), "FixedSpreadLiquidationStrategy/zero-position-address");

--- a/scripts/tests/unit/liquidation-strategies/FixedSpreadLiquidationStrategy.test.js
+++ b/scripts/tests/unit/liquidation-strategies/FixedSpreadLiquidationStrategy.test.js
@@ -12,6 +12,8 @@ const UnitHelpers = require("../../helper/unit");
 const { getContract, createMock } = require("../../helper/contracts");
 const { loadFixture } = require("../../helper/fixtures");
 
+const LIQUIDATION_ENGINE_ROLE = '0x73cc1824a5ac1764c2e141cf3615a9dcb73677c4e5be5154addc88d3e0cc1480'
+
 const loadFixtureHandler = async () => {
     const mockedCollateralTokenAdapter = await createMock("TokenAdapter");
     const mockedCollateralPoolConfig = await createMock("CollateralPoolConfig");
@@ -33,6 +35,8 @@ const loadFixtureHandler = async () => {
     await mockedSystemDebtEngine.mock.surplusBuffer.returns(BigNumber.from("0"))
     await mockedPriceOracle.mock.stableCoinReferencePrice.returns(BigNumber.from("0"))
     await mockedAccessControlConfig.mock.hasRole.returns(true)
+    
+    await mockedAccessControlConfig.mock.LIQUIDATION_ENGINE_ROLE.returns(LIQUIDATION_ENGINE_ROLE) //keccak256 of LIQUIDATION_ENGINE_ROLE
     await mockedStablecoinAdapter.mock.stablecoin.returns(DeployerAddress);
 
     const fixedSpreadLiquidationStrategy = getContract("FixedSpreadLiquidationStrategy", DeployerAddress)


### PR DESCRIPTION
Using hard-coded access role. did not create extra variable due to variables getting too many in a function