### PR TITLE
2.4.43 Unnecessary re-checking of the rights to execute a method in BookKeeper

### DIFF
--- a/contracts/main/stablecoin-core/BookKeeper.sol
+++ b/contracts/main/stablecoin-core/BookKeeper.sol
@@ -194,10 +194,6 @@ contract BookKeeper is IBookKeeper, ICagable, IPausable, BookKeeperMath, Pausabl
     }
 
     function setAccessControlConfig(address _accessControlConfig) external onlyOwner {
-        require(
-            IAccessControlConfig(_accessControlConfig).hasRole(IAccessControlConfig(_accessControlConfig).OWNER_ROLE(), msg.sender),
-            "BookKeeper/msgsender-not-owner"
-        ); // Sanity Check Call
         accessControlConfig = _accessControlConfig;
         emit LogSetAccessControlConfig(msg.sender, _accessControlConfig);
     }


### PR DESCRIPTION
onlyOwner modifier already checks it