### PR TITLE
2.4.48 The sign of the minimum value of type int256 can not be changed

### DIFF
--- a/contracts/main/stablecoin-core/adapters/CollateralTokenAdapter/CollateralTokenAdapter.sol
+++ b/contracts/main/stablecoin-core/adapters/CollateralTokenAdapter/CollateralTokenAdapter.sol
@@ -214,6 +214,7 @@ contract CollateralTokenAdapter is CollateralTokenAdapterMath, ICollateralAdapte
         int256 /* debtShare */,
         bytes calldata _data
     ) external override nonReentrant whenNotPaused onlyProxyWalletOrWhiteListed {
+        require(_collateralValue > -2**255, "CollateralTokenAdapter/tooSmallCollateralValue");
         uint256 _unsignedCollateralValue = _collateralValue < 0 ? uint256(-_collateralValue) : uint256(_collateralValue);
         _moveStake(_source, _destination, _unsignedCollateralValue, _data);
     }


### PR DESCRIPTION
As per auditors:

require(_collateralValue > -2**255, "AnkrCollateralAdapter/tooSmallCollateralValue");