### PR TITLE
2.4.6 Redundant modifier in batchLiquidate in LiquidationEngine

### DIFF
--- a/contracts/main/stablecoin-core/LiquidationEngine.sol
+++ b/contracts/main/stablecoin-core/LiquidationEngine.sol
@@ -118,7 +118,7 @@ contract LiquidationEngine is PausableUpgradeable, ReentrancyGuardUpgradeable, I
         uint256[] calldata _maxDebtShareToBeLiquidateds, // [rad]
         address[] calldata _collateralRecipients,
         bytes[] calldata datas
-    ) external override nonReentrant whenNotPaused onlyWhitelisted {
+    ) external override nonReentrant onlyWhitelisted {
         require(
             _collateralPoolIds.length == _positionAddresses.length &&
                 _collateralPoolIds.length == _debtShareToBeLiquidateds.length &&


### PR DESCRIPTION
There is a redundant modifier in batchLiquidate, whenNotPaused, as it calls this.liquidateForBatch, which has whenNotPaused modifier in it