### PR TITLE
2.4.58 Unnecessary casting to uint64 in DexPriceOracle

### DIFF
--- a/contracts/main/price-oracles/DexPriceOracle.sol
+++ b/contracts/main/price-oracles/DexPriceOracle.sol
@@ -38,6 +38,6 @@ contract DexPriceOracle is Initializable, IFathomDEXOracle {
             : (r0 * (10 ** (decimals1 - decimals0)), r1);
 
         uint price = (normalized0 * 1e18) / normalized1;
-        return (price, uint64(block.timestamp));
+        return (price, block.timestamp);
     }
 }


### PR DESCRIPTION
The casting is not neccessary as in function signature the returns is actually uint256