### PR TITLE
Several important variables are not zeroed in `emergencyWithdraw` in `StableSwapModule`

### DIFF
--- a/contracts/main/interfaces/IStableSwapModuleWrapperRetriever.sol
+++ b/contracts/main/interfaces/IStableSwapModuleWrapperRetriever.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity 0.8.17;
 
-import "../interfaces/IStablecoinAdapter.sol";
-
+///@notice: This interface is only used to retrieve values from stableswap module wrapper so that variables public but not in interface can be fetched
 interface IStableSwapModuleWrapperRetriever {
     function stablecoin() external view returns (address);
     function token() external view returns (address);

--- a/contracts/main/interfaces/IStableSwapModuleWrapperRetriever.sol
+++ b/contracts/main/interfaces/IStableSwapModuleWrapperRetriever.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity 0.8.17;
+
+import "../interfaces/IStablecoinAdapter.sol";
+
+interface IStableSwapModuleWrapperRetriever {
+    function stablecoin() external view returns (address);
+    function token() external view returns (address);
+    function stableSwapModule() external view returns (address);
+    function isDecentralizedState() external view returns (bool);
+    function totalValueDeposited() external view returns (uint256);
+}

--- a/contracts/main/stablecoin-core/StableSwapModule.sol
+++ b/contracts/main/stablecoin-core/StableSwapModule.sol
@@ -132,8 +132,9 @@ contract StableSwapModule is PausableUpgradeable, ReentrancyGuardUpgradeable, IS
      * @notice the function is to only mitigate the bad storage after upgrade.
      * @notice this needs to be removed after its job is done    
      */
-    function udpateTotalValueDepositedAfterUpgrade() external onlyOwner {
-        totalValueDeposited = IStableSwapModuleWrapperRetriever(stableswapWrapper).totalValueDeposited();
+    function udpateTotalValueDeposited() external onlyOwner {
+        uint256 newTotalValueDeposited = IStableSwapModuleWrapperRetriever(stableswapWrapper).totalValueDeposited();
+        totalValueDeposited = newTotalValueDeposited;
     }
 
     function setStableSwapWrapper(address newStableSwapWrapper) external onlyOwner {

--- a/contracts/main/stablecoin-core/StableSwapModule.sol
+++ b/contracts/main/stablecoin-core/StableSwapModule.sol
@@ -12,6 +12,7 @@ import "../interfaces/IStablecoin.sol";
 import "../interfaces/IBookKeeper.sol";
 import "../interfaces/IStableSwapModule.sol";
 import "../utils/SafeToken.sol";
+import "../interfaces/IStableSwapModuleWrapperRetriever.sol";
 
 // Stable Swap Module
 // Allows anyone to go between FUSD and the Token by pooling the liquidity
@@ -125,6 +126,14 @@ contract StableSwapModule is PausableUpgradeable, ReentrancyGuardUpgradeable, IS
         singleSwapLimitNumerator = _singleSwapLimitNumerator;
         numberOfSwapsLimitPerUser = _numberOfSwapsLimitPerUser;
         blocksPerLimit = _blocksPerLimit;
+    }
+
+    /**
+     * @notice the function is to only mitigate the bad storage after upgrade.
+     * @notice this needs to be removed after its job is done    
+     */
+    function udpateTotalValueDepositedAfterUpgrade() external onlyOwner {
+        totalValueDeposited = IStableSwapModuleWrapperRetriever(stableswapWrapper).totalValueDeposited();
     }
 
     function setStableSwapWrapper(address newStableSwapWrapper) external onlyOwner {
@@ -246,7 +255,7 @@ contract StableSwapModule is PausableUpgradeable, ReentrancyGuardUpgradeable, IS
         tokenBalance[_token] += _amount;
         _token.safeTransferFrom(msg.sender, address(this), _amount);
         totalValueDeposited += _convertDecimals(_amount, IToken(_token).decimals(), 18);
-
+    
         if (isDecentralizedState) {
             lastUpdate = block.timestamp;
             remainingDailySwapAmount = _dailySwapLimit();
@@ -296,10 +305,21 @@ contract StableSwapModule is PausableUpgradeable, ReentrancyGuardUpgradeable, IS
         emit LogStableSwapPauseState(false);
     }
 
+    /**
+     * @dev the function withdraws whole balance of both the tokens
+     * @dev Fees is also withdrawn, so once emergencyWithdraw is done, people wont be able to withdraw there fees
+     * @dev All the balances will be reset
+    */
     function emergencyWithdraw(address _account) external override nonReentrant onlyOwnerOrGov whenPaused {
         require(_account != address(0), "withdrawFees/empty-account");
+        
+        totalValueDeposited = 0;
+        totalTokenFeeBalance = 0;
+        totalFXDFeeBalance = 0;
+        
         tokenBalance[token] = 0;
         tokenBalance[stablecoin] = 0;
+        
         token.safeTransfer(_account, token.balanceOf(address(this)));
         stablecoin.safeTransfer(_account, stablecoin.balanceOf(address(this)));
         emit LogEmergencyWithdraw(_account);

--- a/scripts/tests/integration/StableSwapModule.test.js
+++ b/scripts/tests/integration/StableSwapModule.test.js
@@ -253,10 +253,13 @@ describe("StableSwapModule", () => {
 
         context("check for daily limit - depositToken", async() => {
             it("Should update dailyLimit on depositing more token", async() => {
-                await stableSwapModule.setDecentralizedStatesStatus(true,{gasLimit:8000000})
+                await TimeHelpers.increase(1)
+                await stableSwapModule.setDecentralizedStatesStatus(true,{gasLimit:800000})
                 await stableSwapModule.swapTokenToStablecoin(DeployerAddress,ONE_PERCENT_OF_TOTAL_DEPOSIT_SIX_DECIMALS, { gasLimit: 1000000 })    
+                await TimeHelpers.increase(1)
                 await stableSwapModuleWrapper.depositTokens(TO_DEPOSIT,{ gasLimit: 1000000 })
                 //Why GreaterThanOrEqual? Because there is one swap already done which incurs fee so total pool has increased
+                await TimeHelpers.increase(1)
                 const remainingDailySwapAmount = await stableSwapModule.remainingDailySwapAmount() 
                 expect(remainingDailySwapAmount).to.be.gte(FOURTY_PERCENT_OF_TO_DEPOSIT);
             })
@@ -471,7 +474,7 @@ describe("StableSwapModule", () => {
         context("update total value deposited after upgrade", async() => {
             it("totalValueDeposited: should be same before and after upgrade", async() => {
                 const totalValueDepositedBeforeUpdate = await stableSwapModule.totalValueDeposited();
-                await stableSwapModule.udpateTotalValueDepositedAfterUpgrade()
+                await stableSwapModule.udpateTotalValueDeposited()
                 const totalValueDepositedAfterUpdate = await stableSwapModule.totalValueDeposited();
                 expect(totalValueDepositedAfterUpdate).to.be.equal(totalValueDepositedBeforeUpdate)
             })

--- a/scripts/tests/integration/StableSwapModule.test.js
+++ b/scripts/tests/integration/StableSwapModule.test.js
@@ -467,6 +467,17 @@ describe("StableSwapModule", () => {
         })
     })
 
+    describe("#totalValueDeposited", async() => {
+        context("update total value deposited after upgrade", async() => {
+            it("totalValueDeposited: should be same before and after upgrade", async() => {
+                const totalValueDepositedBeforeUpdate = await stableSwapModule.totalValueDeposited();
+                await stableSwapModule.udpateTotalValueDepositedAfterUpgrade()
+                const totalValueDepositedAfterUpdate = await stableSwapModule.totalValueDeposited();
+                expect(totalValueDepositedAfterUpdate).to.be.equal(totalValueDepositedBeforeUpdate)
+            })
+        })
+    })
+
     describe('#unitTests',async() => {
         context("exceed single swap limit", () => {
             it("should revert after setting decentralized state - single swap limit - swapStablecoinToToken", async () => {

--- a/scripts/upgrades/0_062023/zeroedInEmergencyWithdraw-SSM-fix/upgrade-contracts-SSM.js
+++ b/scripts/upgrades/0_062023/zeroedInEmergencyWithdraw-SSM-fix/upgrade-contracts-SSM.js
@@ -1,7 +1,7 @@
 const StableSwapModule = artifacts.require('StableSwapModule.sol');
 
-const proxyAdminAddress = "0xCE4E8a82BCE85dc8CD7A47C9Ea0bE125f0c5d1B7"
-const stableSwapModuleAddress = "0xA090ad1f8EA173128250626a4111B77Fd27a1858"
+const proxyAdminAddress = "0x0000000000000000000000000000000000000000"
+const stableSwapModuleAddress = "0x0000000000000000000000000000000000000000"
 
 module.exports =  async function(deployer) { 
     let promises = [

--- a/scripts/upgrades/0_062023/zeroedInEmergencyWithdraw-SSM-fix/upgrade-contracts-SSM.js
+++ b/scripts/upgrades/0_062023/zeroedInEmergencyWithdraw-SSM-fix/upgrade-contracts-SSM.js
@@ -1,7 +1,7 @@
 const StableSwapModule = artifacts.require('StableSwapModule.sol');
 
-const proxyAdminAddress = "0x0000000000000000000000000000000000000000"
-const stableSwapModuleAddress = "0x0000000000000000000000000000000000000000"
+const proxyAdminAddress = "0xCE4E8a82BCE85dc8CD7A47C9Ea0bE125f0c5d1B7"
+const stableSwapModuleAddress = "0xA090ad1f8EA173128250626a4111B77Fd27a1858"
 
 module.exports =  async function(deployer) { 
     let promises = [

--- a/scripts/upgrades/0_062023/zeroedInEmergencyWithdraw-SSM-fix/zeroedValuesOnEmergencyWithdraw.md
+++ b/scripts/upgrades/0_062023/zeroedInEmergencyWithdraw-SSM-fix/zeroedValuesOnEmergencyWithdraw.md
@@ -1,0 +1,34 @@
+#### Issue Several important variables are not zeroed in `emergencyWithdraw` in `StableSwapModule`
+##### Description
+In the function [`emergencyWithdraw`](https://github.com/Into-the-Fathom/fathom-stablecoin-smart-contracts/blob/6c710b47e07f70c38207c50270f81e1d69c874c8/contracts/main/stablecoin-core/StableSwapModule.sol#L272) in the `StableSwapModule` contract the variables `totalTokenFeeBalance`,`totalFXDFeeBalance`,`totalValueDeposited` are not zeroed.
+
+```solidity
+ function emergencyWithdraw(address _account) external override nonReentrant onlyOwnerOrGov whenPaused {
+    require(_account != address(0), "withdrawFees/empty-account");
+    tokenBalance[token] = 0;
+    tokenBalance[stablecoin] = 0;
+    token.safeTransfer(_account, token.balanceOf(address(this)));
+    stablecoin.safeTransfer(_account, stablecoin.balanceOf(address(this)));
+    emit LogEmergencyWithdraw(_account);
+}
+```
+When the protocol gets unpaused and new liquidity added, the `totalValueDeposited` will contain a sum of "totalValueDeposited before pause" and "just added liquidity", resulting in wrong output of `_checkSingleSwapLimit` and `_dailySwapLimit`: the maximum exchange limit will be much higher than the entire liquidity of the protocol, as well as the daily limit.
+
+Also, the values of `totalTokenFeeBalance` and `totalFXDFeeBalance` will be incorrect because the liquidity has already been withdrawn and the owner has taken this commission and will be able to do it again.
+
+Also in the functions [`swapStablecoinToToken`](https://github.com/Into-the-Fathom/fathom-stablecoin-smart-contracts/tree/6c710b47e07f70c38207c50270f81e1d69c874c8/contracts/main/stablecoin-core/StableSwapModule.sol#L238), [`swapTokenToStablecoin`](https://github.com/Into-the-Fathom/fathom-stablecoin-smart-contracts/tree/6c710b47e07f70c38207c50270f81e1d69c874c8/contracts/main/stablecoin-core/StableSwapModule.sol#L181)  the `totalValueDeposited` variable is not updated to account for the fees accrued, which affects swap limits calculations.
+
+##### Fix
+`totalValueDeposited`, `totalTokenFeeBalance`, `totalFXDFeeBalance` set to zero upon emergencyWithdraw, with addition of function  `udpateTotalValueDeposited()`, to manage storage of totalValueDeposited
+
+
+##### Updagrading contracts
+1. update `upgrade-contracts-SSM.js` script with actual addresses. This script will upgrade the SSM contract with fixes and will call update totalValueDeposited
+2. run `coralx execute --network {network} --path scripts/upgrades/0_062023/zeroedInEmergencyWithdraw-SSM-fix/upgrade-contracts-SSM.js`
+
+
+##### Features still Not Available as of yet:
+1. Accounting for fees
+2. Correct way of handling swap limits after accounting for fees
+3. Handle Emergency Scenarios with Wrapper
+4. Deposit Tokens allowed only relative to balance available on stableswap

--- a/scripts/upgrades/fix-zeroedOnEmergencyWithdraw/upgrade-contracts-SSM.js
+++ b/scripts/upgrades/fix-zeroedOnEmergencyWithdraw/upgrade-contracts-SSM.js
@@ -1,0 +1,19 @@
+const StableSwapModule = artifacts.require('StableSwapModule.sol');
+
+const proxyAdminAddress = "0x0000000000000000000000000000000000000000"
+const stableSwapModuleAddress = "0x0000000000000000000000000000000000000000"
+
+module.exports =  async function(deployer) { 
+    let promises = [
+        deployer.deploy(StableSwapModule, { gas: 7050000 }),
+    ];
+
+    await Promise.all(promises);
+
+    const proxyAdmin = await artifacts.initializeInterfaceAt("FathomProxyAdmin", proxyAdminAddress);
+    const stableSwapModule = await artifacts.initializeInterfaceAt("StableSwapModule", stableSwapModuleAddress);
+
+    await proxyAdmin.upgrade(stableSwapModule.address, StableSwapModule.address, { gas: 8000000 })
+
+    await stableSwapModule.udpateTotalValueDeposited()
+}


### PR DESCRIPTION
Following was done:

- In emergencyWithdraw totalValueDeposited, totalTokenFeeBalance, totalFXDFeeBalance was zeroed
- Added a function udpateTotalValueDeposited() that updates totalValueDeposited to correct value