### PR TITLE
Warning19

### DIFF
--- a/contracts/main/interfaces/ILiquidationStrategy.sol
+++ b/contracts/main/interfaces/ILiquidationStrategy.sol
@@ -7,7 +7,7 @@ interface ILiquidationStrategy {
         uint256 positionDebtShare, // Debt Value                  [rad]
         uint256 positionCollateralAmount, // Collateral Amount           [wad]
         address positionAddress, // Address that will receive any leftover collateral
-        uint256 debtShareToBeLiquidated, // The value of debt to be liquidated as specified by the liquidator [rad]
+        uint256 debtShareToBeLiquidated, // The value of debt to be liquidated as specified by the liquidator [wad]
         uint256 maxDebtShareToBeLiquidated, // The maximum value of debt to be liquidated as specified by the liquidator in case of full liquidation for slippage control [rad]
         address _liquidatorAddress,
         address collateralRecipient,

--- a/contracts/main/stablecoin-core/LiquidationEngine.sol
+++ b/contracts/main/stablecoin-core/LiquidationEngine.sol
@@ -214,7 +214,7 @@ contract LiquidationEngine is PausableUpgradeable, ReentrancyGuardUpgradeable, I
     function _liquidate(
         bytes32 _collateralPoolId,
         address _positionAddress,
-        uint256 _debtShareToBeLiquidated, // [rad]
+        uint256 _debtShareToBeLiquidated, // [wad]
         uint256 _maxDebtShareToBeLiquidated, // [wad]
         address _collateralRecipient,
         bytes calldata _data,


### PR DESCRIPTION
Although the audit issue
19 [NEW] Missing validation of _debtShareToBeLiquidated in LiquidationEngine
recommends to make _debtShareToBeLiquidated bigger than 1 RAD, it is normal that the debtShare in a position is less than 1 RAD, since the amount of debt is not always in RAD unit integer and can be 0.99 RAD or lower. In other words, a position may have 0.5 FXD as debt value, therefore it is not reasonable to limit _debtShareToBeLiquidated's floor value to 1 RAD.

Regardless, this PR fixes the problem that
debtShareToBeLiquidated arg in execute and liquidate had comment that the arg should be in [RAD] but in fact it is [WAD].
