### PR TITLE
Dev stability fee update bug fix

### DIFF
--- a/contracts/main/proxy-actions/FathomStablecoinProxyActions.sol
+++ b/contracts/main/proxy-actions/FathomStablecoinProxyActions.sol
@@ -162,7 +162,6 @@ contract FathomStablecoinProxyActions is CommonMath {
             _positionAddress, 
             _positionAddress, 
             _collateralPoolId, 
-            _stabilityFeeCollector
         );
         // Deposits Fathom Stablecoin amount into the bookKeeper
         stablecoinAdapterDeposit(_stablecoinAdapter, _positionAddress, _requiredStablecoinAmount, _data);
@@ -174,6 +173,7 @@ contract FathomStablecoinProxyActions is CommonMath {
             SafeToken.safeTransferETH(msg.sender, _collateralAmount); // Send XDC to user
         }
         IManager(_manager).updatePrice(_collateralPoolId);
+        IStabilityFeeCollector(_stabilityFeeCollector).collect(_collateralPoolId); // [ray]. Updates stability fee rate
 
         emit LogPaidAmount(_positionAddress, _requiredStablecoinAmount);
     }
@@ -435,7 +435,6 @@ contract FathomStablecoinProxyActions is CommonMath {
             _positionAddress,
             _positionAddress,
             _collateralPoolId,
-            _stabilityFeeCollector
         );
         // Deposits Fathom Stablecoin amount into the bookKeeper
         stablecoinAdapterDeposit(_stablecoinAdapter, _positionAddress, _requiredStablecoinAmount, _data);
@@ -447,7 +446,7 @@ contract FathomStablecoinProxyActions is CommonMath {
             IGenericTokenAdapter(_tokenAdapter).withdraw(msg.sender, _collateralAmount, _data); // Withdraws token amount to the user's wallet as a token
         }
         IManager(_manager).updatePrice(_collateralPoolId);
-
+        IStabilityFeeCollector(_stabilityFeeCollector).collect(_collateralPoolId); // [ray]. Updates stability fee rate
         emit LogPaidAmount(_positionAddress, _requiredStablecoinAmount);
     }
 
@@ -499,9 +498,7 @@ contract FathomStablecoinProxyActions is CommonMath {
         address _usr,
         address _positionAddress,
         bytes32 _collateralPoolId,
-        address _stabilityFeeCollector
     ) internal returns (uint256 _requiredStablecoinAmount) {
-        uint256 _debtAccumulatedRate = IStabilityFeeCollector(_stabilityFeeCollector).collect(_collateralPoolId); // [ray]. Updates stability fee rate
         (, uint256 _debtShare) = IBookKeeper(_bookKeeper).positions(_collateralPoolId, _positionAddress); // [wad]. Gets actual debtShare value of the positionAddress
         uint256 _stablecoinValue = IBookKeeper(_bookKeeper).stablecoin(_usr); // [rad]. Gets actual stablecoin amount in the usr
 

--- a/contracts/main/proxy-actions/FathomStablecoinProxyActions.sol
+++ b/contracts/main/proxy-actions/FathomStablecoinProxyActions.sol
@@ -162,6 +162,7 @@ contract FathomStablecoinProxyActions is CommonMath {
             _positionAddress, 
             _positionAddress, 
             _collateralPoolId, 
+            _stabilityFeeCollector
         );
         // Deposits Fathom Stablecoin amount into the bookKeeper
         stablecoinAdapterDeposit(_stablecoinAdapter, _positionAddress, _requiredStablecoinAmount, _data);
@@ -173,7 +174,6 @@ contract FathomStablecoinProxyActions is CommonMath {
             SafeToken.safeTransferETH(msg.sender, _collateralAmount); // Send XDC to user
         }
         IManager(_manager).updatePrice(_collateralPoolId);
-        IStabilityFeeCollector(_stabilityFeeCollector).collect(_collateralPoolId); // [ray]. Updates stability fee rate
 
         emit LogPaidAmount(_positionAddress, _requiredStablecoinAmount);
     }
@@ -435,6 +435,7 @@ contract FathomStablecoinProxyActions is CommonMath {
             _positionAddress,
             _positionAddress,
             _collateralPoolId,
+            _stabilityFeeCollector
         );
         // Deposits Fathom Stablecoin amount into the bookKeeper
         stablecoinAdapterDeposit(_stablecoinAdapter, _positionAddress, _requiredStablecoinAmount, _data);
@@ -446,7 +447,7 @@ contract FathomStablecoinProxyActions is CommonMath {
             IGenericTokenAdapter(_tokenAdapter).withdraw(msg.sender, _collateralAmount, _data); // Withdraws token amount to the user's wallet as a token
         }
         IManager(_manager).updatePrice(_collateralPoolId);
-        IStabilityFeeCollector(_stabilityFeeCollector).collect(_collateralPoolId); // [ray]. Updates stability fee rate
+
         emit LogPaidAmount(_positionAddress, _requiredStablecoinAmount);
     }
 
@@ -498,7 +499,9 @@ contract FathomStablecoinProxyActions is CommonMath {
         address _usr,
         address _positionAddress,
         bytes32 _collateralPoolId,
+        address _stabilityFeeCollector
     ) internal returns (uint256 _requiredStablecoinAmount) {
+        uint256 _debtAccumulatedRate = IStabilityFeeCollector(_stabilityFeeCollector).collect(_collateralPoolId); // [ray]. Updates stability fee rate
         (, uint256 _debtShare) = IBookKeeper(_bookKeeper).positions(_collateralPoolId, _positionAddress); // [wad]. Gets actual debtShare value of the positionAddress
         uint256 _stablecoinValue = IBookKeeper(_bookKeeper).stablecoin(_usr); // [rad]. Gets actual stablecoin amount in the usr
 

--- a/contracts/main/stablecoin-core/AdminControls.sol
+++ b/contracts/main/stablecoin-core/AdminControls.sol
@@ -68,8 +68,6 @@ contract AdminControls is OwnableUpgradeable {
     /**
     * @notice Pause all core modules of the protocol.
     * @dev This function can only be called by owner or governance role. All related contracts implementing IPausable interface are paused.
-    * @return None.
-    * @event Emits a LogPauseProtocol event.
     */
     function pauseProtocol() external onlyOwnerOrGov {
         IPausable(bookKeeper).pause();
@@ -84,8 +82,6 @@ contract AdminControls is OwnableUpgradeable {
     /**
     * @notice Unpause all core modules of the protocol.
     * @dev This function can only be called by owner or governance role. All related contracts implementing IPausable interface are unpaused.
-    * @return None.
-    * @event Emits a LogUnpauseProtocol event.
     */
     function unpauseProtocol() external onlyOwnerOrGov {
         IPausable(bookKeeper).unpause();

--- a/contracts/main/stablecoin-core/BookKeeper.sol
+++ b/contracts/main/stablecoin-core/BookKeeper.sol
@@ -237,7 +237,6 @@ import "../utils/CommonMath.sol";
     * @param _src The address from which collateral tokens are being moved.
     * @param _dst The address to which collateral tokens are being moved.
     * @param _amount The amount of collateral tokens being moved from the source to the destination.
-    * @emit LogMoveCollateral An event indicating the movement of collateral tokens from source to destination.
     */
 
     function moveCollateral(
@@ -260,7 +259,6 @@ import "../utils/CommonMath.sol";
     * @param _src The source address from which the stablecoin is being moved.
     * @param _dst The destination address to which the stablecoin is being moved.
     * @param _value The amount of stablecoin being moved from the source to the destination.
-    * @emit LogMoveStablecoin An event indicating the movement of stablecoin from source to destination.
     */
 
     function moveStablecoin(address _src, address _dst, uint256 _value) external override nonReentrant whenNotPaused {
@@ -280,8 +278,6 @@ import "../utils/CommonMath.sol";
     * @param _stablecoinOwner The address of the owner of the stablecoin. (positionAddress)
     * @param _collateralValue The change in collateral value. This is added to the position's current locked collateral.
     * @param _debtShare The change in debt share. This is added to the position's current debt share.
-    * @emit LogAdjustPosition An event indicating the successful adjustment of the position's collateral and debt.
-    * @emit StablecoinIssuedAmount An event indicating the total amount of stablecoin issued for the entire system and for the specific collateral pool.
     */
     // solhint-disable function-max-lines
     function adjustPosition(

--- a/contracts/main/stablecoin-core/ShowStopper.sol
+++ b/contracts/main/stablecoin-core/ShowStopper.sol
@@ -243,7 +243,6 @@ contract ShowStopper is CommonMath, IShowStopper, Initializable {
      * @param _collateralPoolId The ID of the collateral pool that the position belongs to.
      * @param _positionAddress The address of the position to redeem locked collateral from.
      * @param _collateralReceiver The address to receive the redeemed collateral tokens.
-     * @param _data Additional data (optional) that may be used by the position manager contract, if applicable.
      */
     function redeemLockedCollateral(
         bytes32 _collateralPoolId,


### PR DESCRIPTION
In the position closure flow, updating the debtAccumulateRate before adjusting the position was introduced. Due to this change, the debtValue that the user needs to pay back at the moment of calling wipe function and the debtvalue user need to be at the moment of adjustPosition differs. To address this issue, I moved the stabilityfeecollector.collect function, which updates the debtAccumulateRate, to the end of the position closure flow. It is inevitable that some users may get away by paying slightly less debtValue, but this difference falls within an acceptable range. Moreover, it is much better than blocking full position closure.

Also this PR includes slight adjustment to Natspec